### PR TITLE
Updated reaction handling

### DIFF
--- a/include/readdy/Simulation.h
+++ b/include/readdy/Simulation.h
@@ -280,8 +280,8 @@ namespace readdy {
          * @param from the type of A
          * @param to1 the type of B
          * @param to2 the type of C
-         * @param productDistance the distance at which the products are placed
          * @param rate the rate at which this reaction is to be performed
+         * @param productDistance the distance at which the products are placed
          * @param weight1 the weight for particle B with respect to the product distance
          * @param weight2 the weight for particle C with respect to the product distance
          * @return a uuid with which this reaction can be removed again
@@ -289,7 +289,7 @@ namespace readdy {
          */
         const boost::uuids::uuid &registerFissionReaction(const std::string &name, const std::string &from,
                                                           const std::string &to1, const std::string &to2,
-                                                          const double productDistance, const double &rate,
+                                                          const double &rate, const double productDistance,
                                                           const double &weight1 = 0.5, const double &weight2 = 0.5);
 
         /**

--- a/include/readdy/Simulation.h
+++ b/include/readdy/Simulation.h
@@ -318,7 +318,7 @@ namespace readdy {
          * @return a uuid with which this reaction can be removed again
          * @todo implement removal of reactions
          */
-        const boost::uuids::uuid &registerDeathReaction(const std::string &name, const std::string &particleType,
+        const boost::uuids::uuid &registerDecayReaction(const std::string &name, const std::string &particleType,
                                                         const double &rate);
 
         virtual void run(const readdy::model::time_step_type steps, const double timeStep);
@@ -328,7 +328,6 @@ namespace readdy {
     private:
         struct Impl;
         std::unique_ptr<readdy::Simulation::Impl> pimpl;
-
         void ensureKernelSelected() const;
     };
 

--- a/include/readdy/Simulation.h
+++ b/include/readdy/Simulation.h
@@ -257,7 +257,7 @@ namespace readdy {
          * @todo implement removal of reactions
          */
         const boost::uuids::uuid &registerConversionReaction(const std::string &name, const std::string &from,
-                                                             const std::string &to, const double &rate);
+                                                             const std::string &to, const double rate);
 
         /**
          * Method to register an enzymatic reaction "A+C->B+C".
@@ -272,7 +272,7 @@ namespace readdy {
          */
         const boost::uuids::uuid &registerEnzymaticReaction(const std::string &name, const std::string &catalyst,
                                                             const std::string &from, const std::string &to,
-                                                            const double &rate, const double &eductDistance);
+                                                            const double rate, const double eductDistance);
 
         /**
          * Method to register a fission reaction "A->B+C".
@@ -289,8 +289,8 @@ namespace readdy {
          */
         const boost::uuids::uuid &registerFissionReaction(const std::string &name, const std::string &from,
                                                           const std::string &to1, const std::string &to2,
-                                                          const double &rate, const double productDistance,
-                                                          const double &weight1 = 0.5, const double &weight2 = 0.5);
+                                                          const double rate, const double productDistance,
+                                                          const double weight1 = 0.5, const double weight2 = 0.5);
 
         /**
          * Method to register a fusion reaction "A+B->C".
@@ -307,8 +307,8 @@ namespace readdy {
          */
         const boost::uuids::uuid &registerFusionReaction(const std::string &name, const std::string &from1,
                                                          const std::string &from2, const std::string &to,
-                                                         const double &rate, const double &eductDistance,
-                                                         const double &weight1 = 0.5, const double &weight2 = 0.5);
+                                                         const double rate, const double eductDistance,
+                                                         const double weight1 = 0.5, const double weight2 = 0.5);
 
         /**
          * Method to register a decay reaction.
@@ -319,7 +319,7 @@ namespace readdy {
          * @todo implement removal of reactions
          */
         const boost::uuids::uuid &registerDecayReaction(const std::string &name, const std::string &particleType,
-                                                        const double &rate);
+                                                        const double rate);
 
         virtual void run(const readdy::model::time_step_type steps, const double timeStep);
 

--- a/include/readdy/common/Utils.h
+++ b/include/readdy/common/Utils.h
@@ -50,6 +50,15 @@ namespace readdy {
             inline bool hasKey(const MapType &map, const KeyType &key) {
                 return map.find(key) != map.end();
             }
+
+            template<template<class, class, class...> class C, typename K, typename V, typename... Args>
+            inline const V &getOrDefault(const C<K, V, Args...> &m, const K &key, const V &defaultValue) {
+                typename C<K, V, Args...>::const_iterator it = m.find(key);
+                if (it == m.end()) {
+                    return defaultValue;
+                }
+                return it->second;
+            }
         }
 
     }

--- a/include/readdy/kernel/singlecpu/SingleCPUKernelStateModel.h
+++ b/include/readdy/kernel/singlecpu/SingleCPUKernelStateModel.h
@@ -27,6 +27,7 @@ namespace readdy {
 
 
                 virtual void updateNeighborList() override;
+                virtual void clearNeighborList() override;
                 virtual void calculateForces() override;
 
                 virtual void addParticle(const readdy::model::Particle &p) override;

--- a/include/readdy/kernel/singlecpu/model/SingleCPUNeighborList.h
+++ b/include/readdy/kernel/singlecpu/model/SingleCPUNeighborList.h
@@ -124,6 +124,10 @@ namespace readdy {
                         fillBoxes(data);
                     }
 
+                    void clear() {
+                        boxes.clear();
+                    }
+
                     virtual void setupNeighboringBoxes(unsigned long i, unsigned long j, unsigned long k) {
                         auto me = getBox(i, j, k);
                         me->addNeighbor(getBox(i + 0, j + 0, k + 1));

--- a/include/readdy/kernel/singlecpu/reactions/SingleCPUReactionFactory.h
+++ b/include/readdy/kernel/singlecpu/reactions/SingleCPUReactionFactory.h
@@ -19,15 +19,28 @@ namespace readdy {
                 class SingleCPUReactionFactory : public readdy::model::reactions::ReactionFactory {
 
                 public:
-                    SingleCPUReactionFactory(SingleCPUKernel const* const kernel);
+                    SingleCPUReactionFactory(SingleCPUKernel const *const kernel);
 
                 protected:
-                    virtual readdy::model::reactions::Conversion *createConversion(const std::string &name, unsigned int from, unsigned int to, const double &rate) const override;
-                    virtual readdy::model::reactions::Enzymatic *createEnzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to, const double &rate, const double &eductDistance) const override;
-                    virtual readdy::model::reactions::Fission *createFission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2, const double productDistance, const double &rate, const double &weight1 = 0.5, const double &weight2 = 0.5) const override;
-                    virtual readdy::model::reactions::Fusion *createFusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to, const double &rate, const double &eductDistance, const double &weight1 = 0.5, const double &weight2 = 0.5) const override;
+                    virtual readdy::model::reactions::Conversion *
+                    createConversion(const std::string &name, unsigned int from, unsigned int to,
+                                     const double &rate) const override;
 
-                    SingleCPUKernel const* const kernel;
+                    virtual readdy::model::reactions::Enzymatic *
+                    createEnzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to,
+                                    const double &rate, const double &eductDistance) const override;
+
+                    virtual readdy::model::reactions::Fission *
+                    createFission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
+                                  const double &rate, const double productDistance, const double &weight1 = 0.5,
+                                  const double &weight2 = 0.5) const override;
+
+                    virtual readdy::model::reactions::Fusion *
+                    createFusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to,
+                                 const double &rate, const double &eductDistance, const double &weight1 = 0.5,
+                                 const double &weight2 = 0.5) const override;
+
+                    SingleCPUKernel const *const kernel;
                 };
             }
         }

--- a/include/readdy/kernel/singlecpu/reactions/SingleCPUReactionFactory.h
+++ b/include/readdy/kernel/singlecpu/reactions/SingleCPUReactionFactory.h
@@ -24,21 +24,21 @@ namespace readdy {
                 protected:
                     virtual readdy::model::reactions::Conversion *
                     createConversion(const std::string &name, unsigned int from, unsigned int to,
-                                     const double &rate) const override;
+                                     const double rate) const override;
 
                     virtual readdy::model::reactions::Enzymatic *
                     createEnzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to,
-                                    const double &rate, const double &eductDistance) const override;
+                                    const double rate, const double eductDistance) const override;
 
                     virtual readdy::model::reactions::Fission *
                     createFission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
-                                  const double &rate, const double productDistance, const double &weight1 = 0.5,
-                                  const double &weight2 = 0.5) const override;
+                                  const double rate, const double productDistance, const double weight1 = 0.5,
+                                  const double weight2 = 0.5) const override;
 
                     virtual readdy::model::reactions::Fusion *
                     createFusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to,
-                                 const double &rate, const double &eductDistance, const double &weight1 = 0.5,
-                                 const double &weight2 = 0.5) const override;
+                                 const double rate, const double eductDistance, const double weight1 = 0.5,
+                                 const double weight2 = 0.5) const override;
 
                     SingleCPUKernel const *const kernel;
                 };

--- a/include/readdy/kernel/singlecpu/reactions/SingleCPUReactions.h
+++ b/include/readdy/kernel/singlecpu/reactions/SingleCPUReactions.h
@@ -22,42 +22,64 @@ namespace readdy {
     namespace kernel {
         namespace singlecpu {
             namespace reactions {
-                class SingleCPUConversion : public readdy::model::reactions::Conversion {
+                class Conversion : public readdy::model::reactions::Conversion {
 
                 public:
-                    SingleCPUConversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double &rate) : Conversion(name, typeFrom, typeTo, rate) { }
+                    Conversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double &rate)
+                            : readdy::model::reactions::Conversion(name, typeFrom, typeTo, rate) {}
 
-                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in, readdy::model::Particle &p1_out, readdy::model::Particle &p2_out) const override;
+                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
+                                         readdy::model::Particle &p1_out,
+                                         readdy::model::Particle &p2_out) const override;
+
+                    virtual Conversion *replicate() const override;
                 };
 
-                class SingleCPUEnzymatic : public readdy::model::reactions::Enzymatic {
+                class Enzymatic : public readdy::model::reactions::Enzymatic {
 
                 public:
-                    SingleCPUEnzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to, const double &rate, const double &eductDistance)
-                            : Enzymatic(name, catalyst, from, to, rate, eductDistance) { }
+                    Enzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to,
+                              const double &rate, const double &eductDistance)
+                            : readdy::model::reactions::Enzymatic(name, catalyst, from, to, rate, eductDistance) {}
 
-                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in, readdy::model::Particle &p1_out, readdy::model::Particle &p2_out) const override;
+                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
+                                         readdy::model::Particle &p1_out,
+                                         readdy::model::Particle &p2_out) const override;
+
+                    virtual Enzymatic *replicate() const override;
                 };
 
-                class SingleCPUFission : public readdy::model::reactions::Fission {
+                class Fission : public readdy::model::reactions::Fission {
 
                 public:
-                    SingleCPUFission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2, const double productDistance, const double &rate, const double& weight1, const double &weight2)
-                            : Fission(name, from, to1, to2, productDistance, rate, weight1, weight2) { }
+                    Fission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
+                            const double &rate, const double productDistance, const double &weight1 = .5,
+                            const double &weight2 = .5)
+                            : readdy::model::reactions::Fission(name, from, to1, to2, rate, productDistance, weight1, weight2) {}
 
-                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in, readdy::model::Particle &p1_out, readdy::model::Particle &p2_out) const override;
+                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
+                                         readdy::model::Particle &p1_out,
+                                         readdy::model::Particle &p2_out) const override;
+
+                    virtual Fission *replicate() const override;
 
                 protected:
-                    std::unique_ptr<readdy::model::RandomProvider> rand = std::make_unique<readdy::model::RandomProvider>();
+                    std::shared_ptr<readdy::model::RandomProvider> rand = std::make_shared<readdy::model::RandomProvider>();
                 };
 
-                class SingleCPUFusion : public readdy::model::reactions::Fusion {
+                class Fusion : public readdy::model::reactions::Fusion {
 
                 public:
-                    SingleCPUFusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to, const double &rate, const double &eductDistance, const double &weight1 = 0.5, const double &weight2 = 0.5)
-                            : Fusion(name, from1, from2, to, rate, eductDistance, weight1, weight2) { }
+                    Fusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to,
+                           const double &rate, const double &eductDistance, const double &weight1 = 0.5,
+                           const double &weight2 = 0.5)
+                            : readdy::model::reactions::Fusion(name, from1, from2, to, rate, eductDistance, weight1, weight2) {}
 
-                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in, readdy::model::Particle &p1_out, readdy::model::Particle &p2_out) const override;
+                    virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
+                                         readdy::model::Particle &p1_out,
+                                         readdy::model::Particle &p2_out) const override;
+
+                    virtual Fusion *replicate() const override;
 
                 };
 

--- a/include/readdy/kernel/singlecpu/reactions/SingleCPUReactions.h
+++ b/include/readdy/kernel/singlecpu/reactions/SingleCPUReactions.h
@@ -25,7 +25,7 @@ namespace readdy {
                 class Conversion : public readdy::model::reactions::Conversion {
 
                 public:
-                    Conversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double &rate)
+                    Conversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double rate)
                             : readdy::model::reactions::Conversion(name, typeFrom, typeTo, rate) {}
 
                     virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
@@ -39,7 +39,7 @@ namespace readdy {
 
                 public:
                     Enzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to,
-                              const double &rate, const double &eductDistance)
+                              const double rate, const double eductDistance)
                             : readdy::model::reactions::Enzymatic(name, catalyst, from, to, rate, eductDistance) {}
 
                     virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
@@ -53,8 +53,8 @@ namespace readdy {
 
                 public:
                     Fission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
-                            const double &rate, const double productDistance, const double &weight1 = .5,
-                            const double &weight2 = .5)
+                            const double &rate, const double productDistance, const double weight1 = .5,
+                            const double weight2 = .5)
                             : readdy::model::reactions::Fission(name, from, to1, to2, rate, productDistance, weight1, weight2) {}
 
                     virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
@@ -71,8 +71,8 @@ namespace readdy {
 
                 public:
                     Fusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to,
-                           const double &rate, const double &eductDistance, const double &weight1 = 0.5,
-                           const double &weight2 = 0.5)
+                           const double rate, const double eductDistance, const double weight1 = 0.5,
+                           const double weight2 = 0.5)
                             : readdy::model::reactions::Fusion(name, from1, from2, to, rate, eductDistance, weight1, weight2) {}
 
                     virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,

--- a/include/readdy/model/KernelContext.h
+++ b/include/readdy/model/KernelContext.h
@@ -74,7 +74,7 @@ namespace readdy {
 
             double getParticleRadius(const std::string &type) const;
 
-            double getParticleRadius(const unsigned int &type) const;
+            double getParticleRadius(const unsigned int type) const;
 
             void setParticleRadius(const std::string &type, const double r);
 
@@ -88,7 +88,7 @@ namespace readdy {
 
             const std::vector<reactions::Reaction<1>*> &getOrder1Reactions(const std::string &type) const;
 
-            const std::vector<reactions::Reaction<1>*> &getOrder1Reactions(const unsigned int &type) const;
+            const std::vector<reactions::Reaction<1>*> &getOrder1Reactions(const unsigned int type) const;
 
             const std::vector<const reactions::Reaction<2> *> getAllOrder2Reactions() const;
 
@@ -97,8 +97,8 @@ namespace readdy {
             const std::vector<reactions::Reaction<2>*> &getOrder2Reactions(const std::string &type1,
                                                                            const std::string &type2) const;
 
-            const std::vector<reactions::Reaction<2>*> &getOrder2Reactions(const unsigned int &type1,
-                                                                           const unsigned int &type2) const;
+            const std::vector<reactions::Reaction<2>*> &getOrder2Reactions(const unsigned int type1,
+                                                                           const unsigned int type2) const;
 
             template<typename R, unsigned int N = R::n_educts>
             const boost::uuids::uuid &registerReaction(const R* const r, typename std::enable_if<std::is_base_of<reactions::Reaction<N>, R>::value>::type* = 0) {
@@ -107,7 +107,7 @@ namespace readdy {
 
             template<typename R>
             const boost::uuids::uuid &registerReaction(std::unique_ptr<R> r, typename std::enable_if<std::is_base_of<reactions::Reaction<1>, R>::value>::type* = 0) {
-                BOOST_LOG_TRIVIAL(debug) << "registering reaction " << *r;
+                BOOST_LOG_TRIVIAL(trace) << "registering reaction " << *r;
                 const auto type = r->getEducts()[0];
                 if (internalReactionOneEductRegistry->find(type) == internalReactionOneEductRegistry->end()) {
                     internalReactionOneEductRegistry->emplace(type,std::vector<std::unique_ptr<reactions::Reaction<1>>>());
@@ -118,7 +118,7 @@ namespace readdy {
 
             template<typename R>
             const boost::uuids::uuid &registerReaction(std::unique_ptr<R> r, typename std::enable_if<std::is_base_of<reactions::Reaction<2>, R>::value>::type* = 0) {
-                BOOST_LOG_TRIVIAL(debug) << "registering reaction " << *r;
+                BOOST_LOG_TRIVIAL(trace) << "registering reaction " << *r;
                 const auto t1 = r->getEducts()[0];
                 const auto t2 = r->getEducts()[1];
 

--- a/include/readdy/model/KernelContext.h
+++ b/include/readdy/model/KernelContext.h
@@ -32,6 +32,14 @@ namespace readdy {
 
         class KernelContext {
         public:
+            
+            using rdy_pot_1 = readdy::model::potentials::PotentialOrder1;
+            using rdy_pot_1_registry = std::unordered_map<unsigned int, std::vector<rdy_pot_1*>>;
+            
+            using rdy_pot_2 = readdy::model::potentials::PotentialOrder2;
+            using rdy_pot_2_registry = std::unordered_map<readdy::util::ParticleTypePair, 
+                    std::vector<rdy_pot_2*>, readdy::util::ParticleTypePairHasher>;
+            
             double getKBT() const;
 
             void setKBT(double kBT);
@@ -80,42 +88,52 @@ namespace readdy {
 
             const reactions::Reaction<2> *const getReactionOrder2WithName(const std::string &name) const;
 
-            const std::vector<reactions::Reaction<2>*> &getOrder2Reactions(const std::string &type1, const std::string &type2) const;
+            const std::vector<reactions::Reaction<2>*> &getOrder2Reactions(const std::string &type1,
+                                                                           const std::string &type2) const;
 
-            const std::vector<reactions::Reaction<2>*> &getOrder2Reactions(const unsigned int &type1, const unsigned int &type2) const;
+            const std::vector<reactions::Reaction<2>*> &getOrder2Reactions(const unsigned int &type1,
+                                                                           const unsigned int &type2) const;
 
-            const boost::uuids::uuid &registerConversionReaction(const std::string &name, const std::string &from, const std::string &to, const double &rate);
+            const boost::uuids::uuid &registerConversionReaction(const std::string &name, const std::string &from,
+                                                                 const std::string &to, const double &rate);
 
-            const boost::uuids::uuid &registerEnzymaticReaction(const std::string &name, const std::string &catalyst, const std::string &from, const std::string &to, const double &rate,
-                                                                const double &eductDistance);
+            const boost::uuids::uuid &registerEnzymaticReaction(const std::string &name, const std::string &catalyst,
+                                                                const std::string &from, const std::string &to,
+                                                                const double &rate, const double &eductDistance);
 
-            const boost::uuids::uuid &registerFissionReaction(const std::string &name, const std::string &from, const std::string &to1, const std::string &to2, const double productDistance,
-                                                              const double &rate, const double &weight1 = 0.5, const double &weight2 = 0.5);
+            const boost::uuids::uuid &registerFissionReaction(const std::string &name, const std::string &from,
+                                                              const std::string &to1, const std::string &to2,
+                                                              const double &rate, const double productDistance,
+                                                              const double &weight1 = 0.5, const double &weight2 = 0.5);
 
-            const boost::uuids::uuid &registerFusionReaction(const std::string &name, const std::string &from1, const std::string &from2, const std::string &to, const double &rate,
-                                                             const double &eductDistance, const double &weight1 = 0.5, const double &weight2 = 0.5);
+            const boost::uuids::uuid &registerFusionReaction(const std::string &name, const std::string &from1,
+                                                             const std::string &from2, const std::string &to,
+                                                             const double &rate, const double &eductDistance,
+                                                             const double &weight1 = 0.5, const double &weight2 = 0.5);
 
-            const boost::uuids::uuid &registerDeathReaction(const std::string &name, const std::string &particleType, const double &rate);
+            const boost::uuids::uuid &registerDeathReaction(const std::string &name,
+                                                            const std::string &particleType, const double &rate);
 
             void deregisterPotential(const boost::uuids::uuid &potential);
 
-            const boost::uuids::uuid &registerOrder1Potential(potentials::PotentialOrder1 const *const potential, const std::string &type);
+            const boost::uuids::uuid &registerOrder1Potential(rdy_pot_1 const *const, const std::string&);
 
-            std::vector<potentials::PotentialOrder1*> getOrder1Potentials(const std::string &type) const;
+            std::vector<rdy_pot_1*> getOrder1Potentials(const std::string &type) const;
 
-            std::vector<potentials::PotentialOrder1*> getOrder1Potentials(const unsigned int type) const;
+            std::vector<rdy_pot_1*> getOrder1Potentials(const unsigned int type) const;
 
-            const std::unordered_map<unsigned int, std::vector<potentials::PotentialOrder1*>> getAllOrder1Potentials() const;
+            const rdy_pot_1_registry getAllOrder1Potentials() const;
 
             std::unordered_set<unsigned int> getAllOrder1RegisteredPotentialTypes() const;
 
-            const boost::uuids::uuid &registerOrder2Potential(potentials::PotentialOrder2 const *const potential, const std::string &type1, const std::string &type2);
+            const boost::uuids::uuid &registerOrder2Potential(rdy_pot_2 const *const potential,
+                                                              const std::string &type1, const std::string &type2);
 
-            const std::vector<potentials::PotentialOrder2*> &getOrder2Potentials(const std::string &type1, const std::string &type2) const;
+            const std::vector<rdy_pot_2*> &getOrder2Potentials(const std::string&, const std::string&) const;
 
-            const std::vector<potentials::PotentialOrder2*> &getOrder2Potentials(const unsigned int type1, const unsigned int type2) const;
+            const std::vector<rdy_pot_2*> &getOrder2Potentials(const unsigned int, const unsigned int) const;
 
-            const std::unordered_map<readdy::util::ParticleTypePair, std::vector<potentials::PotentialOrder2*>, readdy::util::ParticleTypePairHasher> getAllOrder2Potentials() const;
+            const rdy_pot_2_registry getAllOrder2Potentials() const;
 
             std::vector<std::tuple<unsigned int, unsigned int>> getAllOrder2RegisteredPotentialTypes() const;
 

--- a/include/readdy/model/KernelStateModel.h
+++ b/include/readdy/model/KernelStateModel.h
@@ -29,6 +29,7 @@ namespace readdy {
             virtual const std::vector<Particle> getParticles() const = 0;
 
             virtual void updateNeighborList() = 0;
+            virtual void clearNeighborList() = 0;
             virtual void calculateForces() = 0;
 
             virtual void addParticle(const Particle &p) = 0;

--- a/include/readdy/model/RandomProvider.h
+++ b/include/readdy/model/RandomProvider.h
@@ -22,9 +22,9 @@ namespace readdy {
             ~RandomProvider();
             RandomProvider(RandomProvider&& rhs);
             RandomProvider& operator=(RandomProvider&& rhs);
-            virtual double getNormal(const double &mean = 0.0, const double &variance = 1.0);
+            virtual double getNormal(const double mean = 0.0, const double variance = 1.0);
             virtual double getUniform(double a = 0.0, double b = 1.0);
-            virtual Vec3 getNormal3 (const double &mean = 0.0, const double &variance = 1.0);
+            virtual Vec3 getNormal3 (const double mean = 0.0, const double variance = 1.0);
         private:
             struct Impl;
             std::unique_ptr<Impl> pimpl;

--- a/include/readdy/model/Vec3.h
+++ b/include/readdy/model/Vec3.h
@@ -43,7 +43,7 @@ namespace readdy {
 
             friend Vec3 operator-(const Vec3 &lhs, const Vec3 &rhs);
 
-            friend Vec3 operator/(const Vec3& lhs, const double &rhs);
+            friend Vec3 operator/(const Vec3& lhs, const double rhs);
 
             friend bool operator>=(const Vec3 &lhs, const Vec3 &rhs);
             friend bool operator<=(const Vec3 &lhs, const Vec3 &rhs);
@@ -67,7 +67,7 @@ namespace readdy {
         }
 
         template<bool PX, bool PY, bool PZ>
-        inline void fixPosition(Vec3 &vec, const double &dx, const double &dy, const double &dz) {
+        inline void fixPosition(Vec3 &vec, const double dx, const double dy, const double dz) {
             if (PX) {
                 vec[0] -= floor((vec[0] + .5 * dx) / dx) * dx;
             }
@@ -82,7 +82,7 @@ namespace readdy {
         void fixPosition(Vec3 &vec, const std::array<bool, 3> &periodic, const std::array<double, 3> &boxSize);
 
         template<bool PX, bool PY, bool PZ>
-        inline Vec3 shortestDifference(const Vec3 &lhs, const Vec3 &rhs, const double &dx, const double &dy, const double &dz) {
+        inline Vec3 shortestDifference(const Vec3 &lhs, const Vec3 &rhs, const double dx, const double dy, const double dz) {
             auto dv = rhs - lhs;
             if (PX) {
                 if (dv[0] > dx * .5) dv[0] -= dx;
@@ -100,7 +100,7 @@ namespace readdy {
         };
 
         template<bool PX, bool PY, bool PZ>
-        inline double distSquared(const Vec3 &lhs, const Vec3 &rhs, const double &dx, const double &dy, const double &dz) {
+        inline double distSquared(const Vec3 &lhs, const Vec3 &rhs, const double dx, const double dy, const double dz) {
             auto dv = shortestDifference<PX, PY, PZ>(lhs, rhs, dx, dy, dz);
             return dv * dv;
         };

--- a/include/readdy/model/potentials/PotentialOrder1.h
+++ b/include/readdy/model/potentials/PotentialOrder1.h
@@ -26,7 +26,7 @@ namespace readdy {
                 virtual void calculateForce(Vec3 &force, const Vec3& position) const = 0;
                 virtual void calculateForceAndEnergy(Vec3 &force, double &energy, const Vec3& position) const = 0;
 
-                virtual void configureForType(const unsigned int &type) {}
+                virtual void configureForType(const unsigned int type) {}
 
                 virtual double getRelevantLengthScale() const noexcept = 0;
 

--- a/include/readdy/model/potentials/PotentialsOrder1.h
+++ b/include/readdy/model/potentials/PotentialsOrder1.h
@@ -24,7 +24,7 @@ namespace readdy {
 
                 virtual CubePotential *replicate() const override = 0;
 
-                virtual void configureForType(const unsigned int &type) override;
+                virtual void configureForType(const unsigned int type) override;
 
                 const Vec3 &getOrigin() const;
                 void setOrigin(const Vec3 &origin);

--- a/include/readdy/model/programs/Programs.h
+++ b/include/readdy/model/programs/Programs.h
@@ -52,7 +52,11 @@ namespace readdy {
 
             class UpdateNeighborList : public Program {
             public:
+                enum Action { create, clear };
                 UpdateNeighborList() : Program() {}
+                void setAction(Action action) { UpdateNeighborList::action = action; }
+            protected:
+                Action action = Action::create;
             };
 
             namespace reactions {

--- a/include/readdy/model/reactions/Conversion.h
+++ b/include/readdy/model/reactions/Conversion.h
@@ -19,18 +19,18 @@ namespace readdy {
             class Conversion : public Reaction<1> {
 
             public:
-                Conversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double &rate) :
+                Conversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double rate) :
                         Reaction(name, rate, 0 ,0, 1)
                 {
                     educts = {typeFrom};
                     products = {typeTo};
                 }
 
-                const unsigned int& getTypeFrom() const {
+                const unsigned int getTypeFrom() const {
                     return educts[0];
                 }
 
-                const unsigned int& getTypeTo() const {
+                const unsigned int getTypeTo() const {
                     return products[0];
                 }
 

--- a/include/readdy/model/reactions/Conversion.h
+++ b/include/readdy/model/reactions/Conversion.h
@@ -34,6 +34,9 @@ namespace readdy {
                     return products[0];
                 }
 
+                virtual Conversion *replicate() const override {
+                    return new Conversion(*this);
+                }
             };
         }
     }

--- a/include/readdy/model/reactions/Decay.h
+++ b/include/readdy/model/reactions/Decay.h
@@ -16,10 +16,10 @@
 namespace readdy {
     namespace model {
         namespace reactions {
-            class Death : public Reaction<1> {
+            class Decay : public Reaction<1> {
 
             public:
-                Death(const std::string &name, unsigned int typeFrom, const double &rate) : Reaction(name, rate, 0, 0, 0) {
+                Decay(const std::string &name, unsigned int typeFrom, const double &rate) : Reaction(name, rate, 0, 0, 0) {
                     educts[0] = typeFrom;
                 }
 
@@ -29,6 +29,9 @@ namespace readdy {
 
                 virtual void perform(const Particle &p1_in, const Particle &p2_in, Particle &p1_out, Particle &p2_out) const override { };
 
+                virtual Decay *replicate() const override {
+                    return new Decay(*this);
+                }
             };
         }
     }

--- a/include/readdy/model/reactions/Decay.h
+++ b/include/readdy/model/reactions/Decay.h
@@ -19,11 +19,11 @@ namespace readdy {
             class Decay : public Reaction<1> {
 
             public:
-                Decay(const std::string &name, unsigned int typeFrom, const double &rate) : Reaction(name, rate, 0, 0, 0) {
+                Decay(const std::string &name, unsigned int typeFrom, const double rate) : Reaction(name, rate, 0, 0, 0) {
                     educts[0] = typeFrom;
                 }
 
-                const unsigned int &getTypeFrom() const {
+                const unsigned int getTypeFrom() const {
                     return educts[0];
                 }
 

--- a/include/readdy/model/reactions/Enzymatic.h
+++ b/include/readdy/model/reactions/Enzymatic.h
@@ -18,7 +18,7 @@ namespace readdy {
             class Enzymatic : public Reaction<2> {
 
             public:
-                Enzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to, const double &rate, const double &eductDistance) :
+                Enzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to, const double rate, const double eductDistance) :
                         Reaction(name, rate, eductDistance, 0, 2)
                 {
                     educts = {from, catalyst};
@@ -26,15 +26,15 @@ namespace readdy {
                 }
 
 
-                const unsigned int& getCatalyst() const {
+                const unsigned int getCatalyst() const {
                     return educts[1];
                 }
 
-                const unsigned int& getFrom() const {
+                const unsigned int getFrom() const {
                     return educts[0];
                 }
 
-                const unsigned int& getTo() const {
+                const unsigned int getTo() const {
                     return products[0];
                 }
 

--- a/include/readdy/model/reactions/Enzymatic.h
+++ b/include/readdy/model/reactions/Enzymatic.h
@@ -38,6 +38,10 @@ namespace readdy {
                     return products[0];
                 }
 
+                virtual Enzymatic *replicate() const override {
+                    return new Enzymatic(*this);
+                }
+
             };
         }
     }

--- a/include/readdy/model/reactions/Fission.h
+++ b/include/readdy/model/reactions/Fission.h
@@ -21,7 +21,7 @@ namespace readdy {
 
             public:
                 Fission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
-                        const double productDistance, const double &rate, const double &weight1 = 0.5,
+                        const double &rate, const double productDistance, const double &weight1 = 0.5,
                         const double &weight2 = 0.5) :
                         Reaction(name, rate, 0, productDistance, 2), weight1(weight1), weight2(weight2) {
                     educts = {from};
@@ -54,6 +54,10 @@ namespace readdy {
 
                 const double &getWeight2() const {
                     return weight2;
+                }
+
+                virtual Fission *replicate() const override {
+                    return new Fission(*this);
                 }
 
             protected:

--- a/include/readdy/model/reactions/Fission.h
+++ b/include/readdy/model/reactions/Fission.h
@@ -21,8 +21,8 @@ namespace readdy {
 
             public:
                 Fission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
-                        const double &rate, const double productDistance, const double &weight1 = 0.5,
-                        const double &weight2 = 0.5) :
+                        const double rate, const double productDistance, const double weight1 = 0.5,
+                        const double weight2 = 0.5) :
                         Reaction(name, rate, 0, productDistance, 2), weight1(weight1), weight2(weight2) {
                     educts = {from};
                     products = {to1, to2};
@@ -36,23 +36,23 @@ namespace readdy {
                     }
                 }
 
-                const unsigned int &getFrom() const {
+                const unsigned int getFrom() const {
                     return educts[0];
                 }
 
-                const unsigned int &getTo1() const {
+                const unsigned int getTo1() const {
                     return products[0];
                 }
 
-                const unsigned int &getTo2() const {
+                const unsigned int getTo2() const {
                     return products[1];
                 }
 
-                const double &getWeight1() const {
+                const double getWeight1() const {
                     return weight1;
                 }
 
-                const double &getWeight2() const {
+                const double getWeight2() const {
                     return weight2;
                 }
 

--- a/include/readdy/model/reactions/Fusion.h
+++ b/include/readdy/model/reactions/Fusion.h
@@ -56,6 +56,10 @@ namespace readdy {
                     return weight2;
                 }
 
+                virtual Fusion *replicate() const override {
+                    return new Fusion(*this);
+                }
+
             protected:
                 double weight1, weight2;
 

--- a/include/readdy/model/reactions/Fusion.h
+++ b/include/readdy/model/reactions/Fusion.h
@@ -21,8 +21,8 @@ namespace readdy {
 
             public:
                 Fusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to,
-                       const double &rate, const double &eductDistance, const double &weight1 = 0.5,
-                       const double &weight2 = 0.5) :
+                       const double rate, const double eductDistance, const double weight1 = 0.5,
+                       const double weight2 = 0.5) :
                         Reaction(name, rate, eductDistance, 0, 1), weight1(weight1), weight2(weight2) {
                     educts = {from1, from2};
                     products = {to};
@@ -36,23 +36,23 @@ namespace readdy {
                     }
                 }
 
-                const unsigned int &getFrom1() const {
+                const unsigned int getFrom1() const {
                     return educts[0];
                 }
 
-                const unsigned int &getFrom2() const {
+                const unsigned int getFrom2() const {
                     return educts[1];
                 }
 
-                const unsigned int &getTo() const {
+                const unsigned int getTo() const {
                     return products[0];
                 }
 
-                const double &getWeight1() const {
+                const double getWeight1() const {
                     return weight1;
                 }
 
-                const double &getWeight2() const {
+                const double getWeight2() const {
                     return weight2;
                 }
 

--- a/include/readdy/model/reactions/Reaction.h
+++ b/include/readdy/model/reactions/Reaction.h
@@ -26,7 +26,10 @@ namespace readdy {
             class Reaction {
 
             public:
-                Reaction(const std::string &name, const double &rate, const double &eductDistance, const double &productDistance, const unsigned int n_products) :
+                static constexpr unsigned int n_educts = N_EDUCTS;
+
+                Reaction(const std::string &name, const double rate, const double eductDistance,
+                         const double productDistance, const unsigned int n_products) :
                         name(name),
                         id(boost::uuids::random_generator()()),
                         rate(rate),
@@ -45,30 +48,55 @@ namespace readdy {
                     return id;
                 }
 
-                const double &getRate() const {
+                const double getRate() const {
                     return rate;
                 }
 
-                const unsigned int &getNEducts() const {
+                const unsigned int getNEducts() const {
                     return _n_educts;
                 }
 
-                const unsigned int &getNProducts() const {
+                const unsigned int getNProducts() const {
                     return _n_products;
                 }
 
-                const double &getEductDistance() const {
+                const double getEductDistance() const {
                     return eductDistance;
                 }
 
-                const double &getProductDistance() const {
+                const double getProductDistance() const {
                     return productDistance;
                 }
 
-                virtual void perform(const Particle &p1_in, const Particle &p2_in, Particle &p1_out, Particle &p2_out) const { };
+                virtual void perform(const Particle &p1_in, const Particle &p2_in,
+                                     Particle &p1_out, Particle &p2_out) const { };
 
-                /*template<unsigned int _N>
-                friend std::ostream &operator<<(std::ostream& os, const Reaction& reaction);*/
+                virtual Reaction<N_EDUCTS>* replicate() const = 0;
+
+                friend std::ostream &operator<<(std::ostream &os, const Reaction &reaction) {
+                    os << "Reaction(\"" << reaction.name << "\", N_Educts=" << reaction._n_educts << ", N_Products="
+                       << reaction._n_products << ", (";
+                    for (int i = 0; i < reaction._n_educts; i++) {
+                        if (i > 0) os << ",";
+                        os << reaction.educts[i];
+                    }
+                    os << ") -> (";
+                    for (int i = 0; i < reaction._n_products; i++) {
+                        if (i > 0) os << ",";
+                        os << reaction.products[i];
+                    }
+                    os << "), rate=" << reaction.rate << ", eductDist=" << reaction.eductDistance << ", prodDist="
+                       << reaction.productDistance << ")";
+                    return os;
+                }
+
+                const std::array<unsigned int, N_EDUCTS> &getEducts() const {
+                    return educts;
+                }
+
+                const std::array<unsigned int, 2> &getProducts() const {
+                    return products;
+                }
 
             protected:
                 const unsigned int _n_educts = N_EDUCTS;
@@ -81,22 +109,6 @@ namespace readdy {
                 const double eductDistance;
                 const double productDistance;
             };
-
-            /*template<unsigned int _N>
-            inline std::ostream& operator<<(std::ostream& os, const Reaction<_N>& reaction) {
-                os << "Reaction(\"" << reaction.name <<"\", N_Educts="<<_N<<", N_Products="<<reaction._n_products<<", (";
-                for(int i = 0; i < _N; i++) {
-                    if(i > 0) os << ",";
-                    os << reaction.educts[i];
-                }
-                os <<") -> (";
-                for(int i = 0; i < reaction._n_products; i++) {
-                    if(i > 0) os << ",";
-                    os << reaction.products[i];
-                }
-                os <<"), rate="<<reaction.rate<<", eductDist="<<reaction.eductDistance<<", prodDist="<<reaction.productDistance<<")";
-                return os;
-            }*/
 
         }
     }

--- a/include/readdy/model/reactions/ReactionFactory.h
+++ b/include/readdy/model/reactions/ReactionFactory.h
@@ -21,7 +21,7 @@
 #include "Enzymatic.h"
 #include "Fission.h"
 #include "Fusion.h"
-#include "Death.h"
+#include "Decay.h"
 
 namespace readdy {
     namespace model {
@@ -47,9 +47,9 @@ namespace readdy {
                     return new Enzymatic(name, catalyst, from, to, rate, eductDistance);
                 };
                 virtual Fission* createFission(const std::string &name, unsigned int from, unsigned int to1,
-                                               unsigned int to2, const double productDistance, const double &rate,
+                                               unsigned int to2, const double &rate, const double productDistance,
                                                const double &weight1 = 0.5, const double &weight2 = 0.5) const {
-                    return new Fission(name, from, to1, to2, productDistance, rate, weight1, weight2);
+                    return new Fission(name, from, to1, to2, rate, productDistance, weight1, weight2);
                 };
                 virtual Fusion* createFusion(const std::string &name, unsigned int from1, unsigned int from2,
                                              unsigned int to, const double &rate, const double &eductDistance,
@@ -69,25 +69,25 @@ namespace readdy {
 
 
             template<typename... Args> struct ReactionFactory::get_dispatcher<Conversion, Args...> {
-                static Conversion *impl(const ReactionFactory * self, Args... args) {
+                static Conversion *impl(const ReactionFactory * self, Args&&... args) {
                     return self->createConversion(std::forward<Args>(args)...);
                 }
             };
 
             template<typename... Args> struct ReactionFactory::get_dispatcher<Enzymatic, Args...> {
-                static Enzymatic *impl(const ReactionFactory *self, Args... args) {
+                static Enzymatic *impl(const ReactionFactory *self, Args&&... args) {
                     return self->createEnzymatic(std::forward<Args>(args)...);
                 }
             };
 
             template<typename... Args> struct ReactionFactory::get_dispatcher<Fission, Args...> {
-                static Fission *impl(const ReactionFactory *self, Args... args) {
+                static Fission *impl(const ReactionFactory *self, Args&&... args) {
                     return self->createFission(std::forward<Args>(args)...);
                 }
             };
 
             template<typename... Args> struct ReactionFactory::get_dispatcher<Fusion, Args...> {
-                static Fusion *impl(const ReactionFactory *self, Args... args) {
+                static Fusion *impl(const ReactionFactory *self, Args&&... args) {
                     return self->createFusion(std::forward<Args>(args)...);
                 }
             };

--- a/include/readdy/model/reactions/ReactionFactory.h
+++ b/include/readdy/model/reactions/ReactionFactory.h
@@ -38,22 +38,22 @@ namespace readdy {
 
             protected:
                 virtual Conversion* createConversion(const std::string &name, unsigned int from, unsigned int to,
-                                                     const double& rate) const {
+                                                     const double rate) const {
                     return new Conversion(name, from, to, rate);
                 };
                 virtual Enzymatic* createEnzymatic(const std::string &name, unsigned int catalyst, unsigned int from,
-                                                   unsigned int to, const double &rate,
-                                                   const double &eductDistance) const {
+                                                   unsigned int to, const double rate,
+                                                   const double eductDistance) const {
                     return new Enzymatic(name, catalyst, from, to, rate, eductDistance);
                 };
                 virtual Fission* createFission(const std::string &name, unsigned int from, unsigned int to1,
-                                               unsigned int to2, const double &rate, const double productDistance,
-                                               const double &weight1 = 0.5, const double &weight2 = 0.5) const {
+                                               unsigned int to2, const double rate, const double productDistance,
+                                               const double weight1 = 0.5, const double weight2 = 0.5) const {
                     return new Fission(name, from, to1, to2, rate, productDistance, weight1, weight2);
                 };
                 virtual Fusion* createFusion(const std::string &name, unsigned int from1, unsigned int from2,
-                                             unsigned int to, const double &rate, const double &eductDistance,
-                                             const double &weight1 = 0.5, const double &weight2 = 0.5) const {
+                                             unsigned int to, const double rate, const double eductDistance,
+                                             const double weight1 = 0.5, const double weight2 = 0.5) const {
                     return new Fusion(name, from1, from2, to, rate, eductDistance, weight1, weight2);
                 };
 

--- a/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
@@ -37,6 +37,9 @@ namespace readdy {
                 readdy::kernel::singlecpu::model::SingleCPUParticleData *const getParticleData() const;
 
                 const model::NeighborList*const getNeighborList() const;
+
+                virtual void clearNeighborList() override;
+
             private:
                 struct Impl;
                 std::unique_ptr<Impl> pimpl;

--- a/kernels/cpu/include/readdy/kernel/cpu/model/NeighborList.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/model/NeighborList.h
@@ -80,6 +80,10 @@ namespace readdy {
                         }
                     }
 
+                    void clear() {
+                        boxes.clear();
+                    }
+
                     virtual void fillBoxes(const singlecpu::model::SingleCPUParticleData &data) {
                         const auto simBoxSize = ctx->getBoxSize();
                         if (maxCutoff > 0) {

--- a/kernels/cpu/include/readdy/kernel/cpu/model/NeighborList.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/model/NeighborList.h
@@ -108,7 +108,7 @@ namespace readdy {
                             }
 
 
-                            {/*
+                            {
                                 const auto size = boxes.size();
                                 const std::size_t grainSize = size / util::getNThreads();
 
@@ -137,9 +137,9 @@ namespace readdy {
                                     threads.push_back(util::ScopedThread(std::thread(worker, i*grainSize, (i+1)*grainSize)));
                                 }
                                 threads.push_back(util::ScopedThread(std::thread(worker, (util::getNThreads()-1)*grainSize, boxes.size())));
-                            */}
+                            }
 
-                            for (auto &&box : boxes) {
+                            /*for (auto &&box : boxes) {
                                 for (long i = 0; i < box.particleIndices.size(); ++i) {
                                     const auto pI = box.particleIndices[i];
                                     for (long j = 0; j < box.particleIndices.size(); ++j) {
@@ -152,7 +152,7 @@ namespace readdy {
                                         }
                                     }
                                 }
-                            }
+                            }*/
                         }
                     }
 

--- a/kernels/cpu/include/readdy/kernel/cpu/programs/UpdateNeighborList.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/programs/UpdateNeighborList.h
@@ -24,7 +24,15 @@ namespace readdy {
                     UpdateNeighborList(CPUKernel *kernel) : kernel(kernel){
                     }
                     virtual void execute() override {
-                        kernel->getKernelStateModel().updateNeighborList();
+                        switch(action) {
+                            case create:
+                                kernel->getKernelStateModel().updateNeighborList();
+                                break;
+                            case clear:
+                                kernel->getKernelStateModel().getNeighborList();
+                                break;
+                        }
+
                     }
 
                 private:

--- a/kernels/cpu/include/readdy/kernel/cpu/reactions/CPUReactionFactory.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/reactions/CPUReactionFactory.h
@@ -21,7 +21,7 @@ namespace readdy {
 
                 struct Conversion : public readdy::model::reactions::Conversion {
 
-                    Conversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double &rate)
+                    Conversion(const std::string &name, unsigned int typeFrom, unsigned int typeTo, const double rate)
                             : readdy::model::reactions::Conversion(name, typeFrom, typeTo, rate) { }
 
                     virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
@@ -39,7 +39,7 @@ namespace readdy {
                 struct Enzymatic : public readdy::model::reactions::Enzymatic {
 
                     Enzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to,
-                              const double &rate, const double &eductDistance) : readdy::model::reactions::Enzymatic(
+                              const double rate, const double eductDistance) : readdy::model::reactions::Enzymatic(
                             name, catalyst, from, to, rate, eductDistance) {
 
                     }
@@ -71,8 +71,8 @@ namespace readdy {
                 struct Fission : public readdy::model::reactions::Fission {
 
                     Fission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
-                            const double &rate, const double productDistance, const double &weight1,
-                            const double &weight2) : readdy::model::reactions::Fission(name, from, to1, to2,
+                            const double rate, const double productDistance, const double weight1,
+                            const double weight2) : readdy::model::reactions::Fission(name, from, to1, to2,
                                                                                        rate, productDistance, weight1,
                                                                                        weight2) { }
 
@@ -100,8 +100,8 @@ namespace readdy {
                 struct Fusion : public readdy::model::reactions::Fusion {
 
                     Fusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to,
-                           const double &rate, const double &eductDistance, const double &weight1,
-                           const double &weight2) : readdy::model::reactions::Fusion(name, from1, from2, to, rate,
+                           const double rate, const double eductDistance, const double weight1,
+                           const double weight2) : readdy::model::reactions::Fusion(name, from1, from2, to, rate,
                                                                                      eductDistance, weight1,
                                                                                      weight2) { }
 
@@ -132,33 +132,33 @@ namespace readdy {
                     virtual readdy::model::reactions::Conversion *createConversion(const std::string &name,
                                                                                    unsigned int from,
                                                                                    unsigned int to,
-                                                                                   const double &rate) const override {
+                                                                                   const double rate) const override {
                         return new Conversion(name, from, to, rate);
                     }
 
                     virtual readdy::model::reactions::Enzymatic *createEnzymatic(const std::string &name,
                                                                                  unsigned int catalyst,
                                                                                  unsigned int from, unsigned int to,
-                                                                                 const double &rate,
-                                                                                 const double &eductDistance) const override {
+                                                                                 const double rate,
+                                                                                 const double eductDistance) const override {
                         return new Enzymatic(name, catalyst, from, to, rate, eductDistance);
                     }
 
                     virtual readdy::model::reactions::Fission *createFission(const std::string &name, unsigned int from,
                                                                              unsigned int to1, unsigned int to2,
-                                                                             const double &rate,
+                                                                             const double rate,
                                                                              const double productDistance,
-                                                                             const double &weight1,
-                                                                             const double &weight2) const override {
+                                                                             const double weight1,
+                                                                             const double weight2) const override {
                         return new Fission(name, from, to1, to2, rate, productDistance, weight1, weight2);
                     }
 
                     virtual readdy::model::reactions::Fusion *createFusion(const std::string &name, unsigned int from1,
                                                                            unsigned int from2, unsigned int to,
-                                                                           const double &rate,
-                                                                           const double &eductDistance,
-                                                                           const double &weight1,
-                                                                           const double &weight2) const override {
+                                                                           const double rate,
+                                                                           const double eductDistance,
+                                                                           const double weight1,
+                                                                           const double weight2) const override {
                         return new Fusion(name, from1, from2, to, rate, eductDistance, weight1,
                                           weight2);
                     }

--- a/kernels/cpu/include/readdy/kernel/cpu/reactions/CPUReactionFactory.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/reactions/CPUReactionFactory.h
@@ -30,6 +30,10 @@ namespace readdy {
                         p1_out.setType(getTypeTo());
                         p1_out.setId(p1_in.getId());
                     }
+
+                    virtual Conversion *replicate() const override {
+                        return new Conversion(*this);
+                    }
                 };
 
                 struct Enzymatic : public readdy::model::reactions::Enzymatic {
@@ -58,14 +62,18 @@ namespace readdy {
                             p2_out.setPos(p1_in.getPos());
                         }
                     }
+
+                    virtual Enzymatic *replicate() const override {
+                        return new Enzymatic(*this);
+                    }
                 };
 
                 struct Fission : public readdy::model::reactions::Fission {
 
                     Fission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2,
-                            const double productDistance, const double &rate, const double &weight1,
+                            const double &rate, const double productDistance, const double &weight1,
                             const double &weight2) : readdy::model::reactions::Fission(name, from, to1, to2,
-                                                                                       productDistance, rate, weight1,
+                                                                                       rate, productDistance, weight1,
                                                                                        weight2) { }
 
                     virtual void perform(const readdy::model::Particle &p1_in, const readdy::model::Particle &p2_in,
@@ -80,8 +88,12 @@ namespace readdy {
                         p2_out.setPos(p1_in.getPos() - getWeight2() * getProductDistance() * n3);
                     }
 
+                    virtual Fission *replicate() const override {
+                        return new Fission(*this);
+                    }
+
                 protected:
-                    std::unique_ptr<readdy::model::RandomProvider> rand = std::make_unique<readdy::model::RandomProvider>();
+                    std::shared_ptr<readdy::model::RandomProvider> rand = std::make_shared<readdy::model::RandomProvider>();
 
                 };
 
@@ -101,6 +113,10 @@ namespace readdy {
                         } else {
                             p1_out.setPos(p2_in.getPos() + getWeight1() * (p1_in.getPos() - p2_in.getPos()));
                         }
+                    }
+
+                    virtual Fusion *replicate() const override {
+                        return new Fusion(*this);
                     }
 
 
@@ -130,11 +146,11 @@ namespace readdy {
 
                     virtual readdy::model::reactions::Fission *createFission(const std::string &name, unsigned int from,
                                                                              unsigned int to1, unsigned int to2,
-                                                                             const double productDistance,
                                                                              const double &rate,
+                                                                             const double productDistance,
                                                                              const double &weight1,
                                                                              const double &weight2) const override {
-                        return new Fission(name, from, to1, to2, productDistance, rate, weight1, weight2);
+                        return new Fission(name, from, to1, to2, rate, productDistance, weight1, weight2);
                     }
 
                     virtual readdy::model::reactions::Fusion *createFusion(const std::string &name, unsigned int from1,

--- a/kernels/cpu/src/CPUKernel.cpp
+++ b/kernels/cpu/src/CPUKernel.cpp
@@ -38,7 +38,7 @@ namespace readdy {
 
             CPUKernel::CPUKernel() : readdy::model::Kernel(name), pimpl(std::make_unique<Impl>()){
                 pimpl->reactionFactory = std::make_unique<reactions::CPUReactionFactory>(this);
-                pimpl->context = std::make_unique<readdy::model::KernelContext>(pimpl->reactionFactory.get());
+                pimpl->context = std::make_unique<readdy::model::KernelContext>();
                 pimpl->programFactory = std::make_unique<programs::CPUProgramFactory>(this);
                 pimpl->stateModel = std::make_unique<CPUStateModel>(pimpl->context.get());
                 pimpl->potentialFactory = std::make_unique<potentials::CPUPotentialFactory>(this);

--- a/kernels/cpu/src/CPUStateModel.cpp
+++ b/kernels/cpu/src/CPUStateModel.cpp
@@ -174,6 +174,10 @@ namespace readdy {
                 return pimpl->neighborList.get();
             }
 
+            void CPUStateModel::clearNeighborList() {
+                pimpl->neighborList->clear();
+            }
+
 
             CPUStateModel::~CPUStateModel() = default;
 

--- a/kernels/cpu/test/CPUTestKernel.cpp
+++ b/kernels/cpu/test/CPUTestKernel.cpp
@@ -21,8 +21,8 @@ namespace {
         kernel->getKernelContext().setBoxSize(10, 10, 10);
         kernel->getKernelContext().setTimeStep(1);
         kernel->getKernelContext().setDiffusionConstant("X", .55);
-        kernel->getKernelContext().registerDeathReaction("X decay", "X", .5);
-        kernel->getKernelContext().registerFissionReaction("X fission", "X", "X", "X", .00, .5);
+        kernel->registerReaction<readdy::model::reactions::Decay>("X decay", "X", .5);
+        kernel->registerReaction<readdy::model::reactions::Fission>("X fission", "X", "X", "X", .00, .5);
 
         auto &&integrator = kernel->createProgram<readdy::model::programs::EulerBDIntegrator>();
         auto &&neighborList = kernel->createProgram<readdy::model::programs::UpdateNeighborList>();
@@ -37,6 +37,8 @@ namespace {
         std::vector<readdy::model::Particle> particlesToBeginWith {n_particles, {0,0,0,typeId}};
         BOOST_LOG_TRIVIAL(debug) << "n_particles="<<particlesToBeginWith.size();
         kernel->getKernelStateModel().addParticles(particlesToBeginWith);
+
+        kernel->getKernelContext().configure();
 
         neighborList->execute();
         for(size_t t = 0; t < 1000; t++) {

--- a/kernels/cpu/test/CPUTestKernel.cpp
+++ b/kernels/cpu/test/CPUTestKernel.cpp
@@ -22,7 +22,7 @@ namespace {
         kernel->getKernelContext().setTimeStep(1);
         kernel->getKernelContext().setDiffusionConstant("X", .55);
         kernel->getKernelContext().registerDeathReaction("X decay", "X", .5);
-        kernel->getKernelContext().registerFissionReaction("X fission", "X", "X", "X", .5, .00);
+        kernel->getKernelContext().registerFissionReaction("X fission", "X", "X", "X", .00, .5);
 
         auto &&integrator = kernel->createProgram<readdy::model::programs::EulerBDIntegrator>();
         auto &&neighborList = kernel->createProgram<readdy::model::programs::UpdateNeighborList>();

--- a/kernels/singlecpu/src/SingleCPUKernel.cpp
+++ b/kernels/singlecpu/src/SingleCPUKernel.cpp
@@ -28,7 +28,7 @@ namespace readdy {
                 pimpl->programs = std::make_unique<programs::SingleCPUProgramFactory>(this);
                 pimpl->potentials = std::make_unique<potentials::SingleCPUPotentialFactory>(this);
                 pimpl->reactions = std::make_unique<reactions::SingleCPUReactionFactory>(this);
-                pimpl->context = std::make_unique<readdy::model::KernelContext>(pimpl->reactions.get());
+                pimpl->context = std::make_unique<readdy::model::KernelContext>();
                 pimpl->model = std::make_unique<SingleCPUKernelStateModel>(pimpl->context.get());
                 pimpl->observables = std::make_unique<observables::SingleCPUObservableFactory>(this);
             }

--- a/kernels/singlecpu/src/SingleCPUKernelStateModel.cpp
+++ b/kernels/singlecpu/src/SingleCPUKernelStateModel.cpp
@@ -120,6 +120,10 @@ namespace readdy {
                 pimpl->neighborList.swap(ptr);
             }
 
+            void SingleCPUKernelStateModel::clearNeighborList() {
+                pimpl->neighborList->clear();
+            }
+
 
             SingleCPUKernelStateModel &SingleCPUKernelStateModel::operator=(SingleCPUKernelStateModel &&rhs) = default;
 

--- a/kernels/singlecpu/src/programs/SingleCPUUpdateNeighborList.cpp
+++ b/kernels/singlecpu/src/programs/SingleCPUUpdateNeighborList.cpp
@@ -15,7 +15,14 @@ namespace readdy {
                 SingleCPUUpdateNeighborList::SingleCPUUpdateNeighborList(SingleCPUKernel *kernel) : kernel(kernel) { }
 
                 void SingleCPUUpdateNeighborList::execute() {
-                    kernel->getKernelStateModel().updateNeighborList();
+                    switch(action) {
+                        case create:
+                            kernel->getKernelStateModel().updateNeighborList();
+                            break;
+                        case clear:
+                            kernel->getKernelStateModel().clearNeighborList();
+                            break;
+                    }
                 }
             }
         }

--- a/kernels/singlecpu/src/reactions/SingleCPUReactionFactory.cpp
+++ b/kernels/singlecpu/src/reactions/SingleCPUReactionFactory.cpp
@@ -22,30 +22,30 @@ namespace readdy {
 
                 readdy::model::reactions::Conversion *
                 SingleCPUReactionFactory::createConversion(const std::string &name, unsigned int from, unsigned int to,
-                                                           const double &rate) const {
+                                                           const double rate) const {
                     return new Conversion(name, from, to, rate);
                 }
 
                 readdy::model::reactions::Enzymatic *
                 SingleCPUReactionFactory::createEnzymatic(const std::string &name, unsigned int catalyst,
-                                                          unsigned int from, unsigned int to, const double &rate,
-                                                          const double &eductDistance) const {
+                                                          unsigned int from, unsigned int to, const double rate,
+                                                          const double eductDistance) const {
                     return new Enzymatic(name, catalyst, from, to, rate, eductDistance);
                 }
 
                 readdy::model::reactions::Fission *
                 SingleCPUReactionFactory::createFission(const std::string &name, unsigned int from, unsigned int to1,
                                                         unsigned int to2,
-                                                        const double &rate, const double productDistance,
-                                                        const double &weight1, const double &weight2) const {
+                                                        const double rate, const double productDistance,
+                                                        const double weight1, const double weight2) const {
                     return new Fission(name, from, to1, to2, rate, productDistance, weight1, weight2);
                 }
 
                 readdy::model::reactions::Fusion *
                 SingleCPUReactionFactory::createFusion(const std::string &name, unsigned int from1, unsigned int from2,
-                                                       unsigned int to, const double &rate,
-                                                       const double &eductDistance, const double &weight1,
-                                                       const double &weight2) const {
+                                                       unsigned int to, const double rate,
+                                                       const double eductDistance, const double weight1,
+                                                       const double weight2) const {
                     return new Fusion(name, from1, from2, to, rate, eductDistance, weight1, weight2);
                 }
 

--- a/kernels/singlecpu/src/reactions/SingleCPUReactionFactory.cpp
+++ b/kernels/singlecpu/src/reactions/SingleCPUReactionFactory.cpp
@@ -15,27 +15,38 @@ namespace readdy {
     namespace kernel {
         namespace singlecpu {
             namespace reactions {
-                SingleCPUReactionFactory::SingleCPUReactionFactory(SingleCPUKernel const *const kernel) : kernel(kernel){
+                SingleCPUReactionFactory::SingleCPUReactionFactory(SingleCPUKernel const *const kernel) : kernel(
+                        kernel) {
 
                 }
 
-                readdy::model::reactions::Conversion *SingleCPUReactionFactory::createConversion(const std::string &name, unsigned int from, unsigned int to, const double &rate) const {
-                    return new SingleCPUConversion(name, from, to, rate);
+                readdy::model::reactions::Conversion *
+                SingleCPUReactionFactory::createConversion(const std::string &name, unsigned int from, unsigned int to,
+                                                           const double &rate) const {
+                    return new Conversion(name, from, to, rate);
                 }
 
-                readdy::model::reactions::Enzymatic *SingleCPUReactionFactory::createEnzymatic(const std::string &name, unsigned int catalyst, unsigned int from, unsigned int to, const double &rate,
-                                                                                       const double &eductDistance) const {
-                    return new SingleCPUEnzymatic(name, catalyst, from, to, rate, eductDistance);
+                readdy::model::reactions::Enzymatic *
+                SingleCPUReactionFactory::createEnzymatic(const std::string &name, unsigned int catalyst,
+                                                          unsigned int from, unsigned int to, const double &rate,
+                                                          const double &eductDistance) const {
+                    return new Enzymatic(name, catalyst, from, to, rate, eductDistance);
                 }
 
-                readdy::model::reactions::Fission *SingleCPUReactionFactory::createFission(const std::string &name, unsigned int from, unsigned int to1, unsigned int to2, const double productDistance,
-                                                                                   const double &rate, const double& weight1, const double& weight2) const {
-                    return new SingleCPUFission(name, from, to1, to2, productDistance, rate, weight1, weight2);
+                readdy::model::reactions::Fission *
+                SingleCPUReactionFactory::createFission(const std::string &name, unsigned int from, unsigned int to1,
+                                                        unsigned int to2,
+                                                        const double &rate, const double productDistance,
+                                                        const double &weight1, const double &weight2) const {
+                    return new Fission(name, from, to1, to2, rate, productDistance, weight1, weight2);
                 }
 
-                readdy::model::reactions::Fusion *SingleCPUReactionFactory::createFusion(const std::string &name, unsigned int from1, unsigned int from2, unsigned int to, const double &rate,
-                                                                                 const double &eductDistance, const double &weight1, const double &weight2) const {
-                    return new SingleCPUFusion(name, from1, from2, to, rate, eductDistance, weight1, weight2);
+                readdy::model::reactions::Fusion *
+                SingleCPUReactionFactory::createFusion(const std::string &name, unsigned int from1, unsigned int from2,
+                                                       unsigned int to, const double &rate,
+                                                       const double &eductDistance, const double &weight1,
+                                                       const double &weight2) const {
+                    return new Fusion(name, from1, from2, to, rate, eductDistance, weight1, weight2);
                 }
 
             }

--- a/kernels/singlecpu/src/reactions/SingleCPUReactions.cpp
+++ b/kernels/singlecpu/src/reactions/SingleCPUReactions.cpp
@@ -9,7 +9,6 @@
 
 #include <readdy/model/Particle.h>
 #include <readdy/kernel/singlecpu/reactions/SingleCPUReactions.h>
-#include <iostream>
 
 using _rdy_particle_t = readdy::model::Particle;
 
@@ -17,14 +16,18 @@ namespace readdy {
     namespace kernel {
         namespace singlecpu {
             namespace reactions {
-                void SingleCPUConversion::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
+                void Conversion::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
                     p1_out.setPos(p1_in.getPos());
                     p1_out.setType(getTypeTo());
                     p1_out.setId(p1_in.getId());
                 }
 
+                Conversion *Conversion::replicate() const {
+                    return new Conversion(*this);
+                }
 
-                void SingleCPUEnzymatic::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
+
+                void Enzymatic::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
                     if (p1_in.getType() == getCatalyst()) {
                         // p1 is the catalyst
                         p1_out.setType(getCatalyst());
@@ -42,7 +45,11 @@ namespace readdy {
                     }
                 }
 
-                void SingleCPUFission::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
+                Enzymatic *Enzymatic::replicate() const {
+                    return new Enzymatic(*this);
+                }
+
+                void Fission::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
                     // as long as the orientation is uniform, it does not matter of which type p1_in and p2_in are.
                     auto n3 = rand->getNormal3();
                     n3 /= sqrt(n3 * n3);
@@ -53,13 +60,21 @@ namespace readdy {
                     p2_out.setPos(p1_in.getPos() - getWeight2() * getProductDistance() * n3);
                 }
 
-                void SingleCPUFusion::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
+                Fission *Fission::replicate() const {
+                    return new Fission(*this);
+                }
+
+                void Fusion::perform(const _rdy_particle_t &p1_in, const _rdy_particle_t &p2_in, _rdy_particle_t &p1_out, _rdy_particle_t &p2_out) const {
                     p1_out.setType(getTo());
                     if (getFrom1() == p1_in.getType()) {
                         p1_out.setPos(p1_in.getPos() + getWeight1() * (p2_in.getPos() - p1_in.getPos()));
                     } else {
                         p1_out.setPos(p2_in.getPos() + getWeight1() * (p1_in.getPos() - p2_in.getPos()));
                     }
+                }
+
+                Fusion *Fusion::replicate() const {
+                    return new Fusion(*this);
                 }
             }
         }

--- a/kernels/singlecpu/test/SingleCPUTestReactions.cpp
+++ b/kernels/singlecpu/test/SingleCPUTestReactions.cpp
@@ -19,7 +19,7 @@ TEST(SingleCPUTestReactions, CheckInOutTypesAndPositions) {
     using fission_t = readdy::model::reactions::Fission;
     using enzymatic_t = readdy::model::reactions::Enzymatic;
     using conversion_t = readdy::model::reactions::Conversion;
-    using death_t = readdy::model::reactions::Death;
+    using death_t = readdy::model::reactions::Decay;
     using particle_t = readdy::model::Particle;
     auto kernel = readdy::plugin::KernelProvider::getInstance().create("SingleCPU");
     kernel->getKernelContext().setPeriodicBoundary(false, false, false);
@@ -62,7 +62,7 @@ TEST(SingleCPUTestReactions, CheckInOutTypesAndPositions) {
     {
         double productDistance = .4;
         double weight1 = .3, weight2 = .7;
-        auto fission = kernel->getReactionFactory().createReaction<fission_t>("C->A+B", 2, 0, 1, productDistance, 1, weight1, weight2);
+        auto fission = kernel->getReactionFactory().createReaction<fission_t>("C->A+B", 2, 0, 1, 1, productDistance, weight1, weight2);
         particle_t p_C{0, 0, 0, 2};
         particle_t p_out1{50, 50, 50, 70};
         particle_t p_out2{50, 50, 50, 70};
@@ -123,14 +123,14 @@ TEST(SingleCPUTestReactions, TestDecay) {
     using fission_t = readdy::model::reactions::Fission;
     using enzymatic_t = readdy::model::reactions::Enzymatic;
     using conversion_t = readdy::model::reactions::Conversion;
-    using death_t = readdy::model::reactions::Death;
+    using death_t = readdy::model::reactions::Decay;
     using particle_t = readdy::model::Particle;
     auto kernel = readdy::plugin::KernelProvider::getInstance().create("SingleCPU");
     kernel->getKernelContext().setBoxSize(10, 10, 10);
     kernel->getKernelContext().setTimeStep(1);
     kernel->getKernelContext().setDiffusionConstant("X", .25);
-    kernel->getKernelContext().registerDeathReaction("X decay", "X", 1);
-    kernel->getKernelContext().registerFissionReaction("X fission", "X", "X", "X", .5, .3);
+    kernel->registerReaction<death_t>("X decay", "X", 1);
+    kernel->registerReaction<fission_t>("X fission", "X", "X", "X", .5, .3);
 
     auto &&integrator = kernel->createProgram<readdy::model::programs::EulerBDIntegrator>();
     auto &&forces = kernel->createProgram<readdy::model::programs::CalculateForces>();
@@ -196,7 +196,7 @@ TEST(SingleCPUTestReactions, TestMultipleReactionTypes) {
     using fission_t = readdy::model::reactions::Fission;
     using enzymatic_t = readdy::model::reactions::Enzymatic;
     using conversion_t = readdy::model::reactions::Conversion;
-    using death_t = readdy::model::reactions::Death;
+    using death_t = readdy::model::reactions::Decay;
     using particle_t = readdy::model::Particle;
     auto kernel = readdy::plugin::KernelProvider::getInstance().create("SingleCPU");
     kernel->getKernelContext().setBoxSize(10, 10, 10);
@@ -208,11 +208,11 @@ TEST(SingleCPUTestReactions, TestMultipleReactionTypes) {
     kernel->getKernelContext().setDiffusionConstant("D", .25);
     kernel->getKernelContext().setDiffusionConstant("E", .25);
 
-    kernel->getKernelContext().registerDeathReaction("A decay", "A", 1);
-    kernel->getKernelContext().registerFusionReaction("B+C->E", "B", "C", "E", 1, 17);
-    kernel->getKernelContext().registerFusionReaction("B+D->A", "B", "D", "A", 1, 17);
-    kernel->getKernelContext().registerConversionReaction("E->A", "E", "A", 1);
-    kernel->getKernelContext().registerConversionReaction("C->D", "C", "D", 1);
+    kernel->registerReaction<death_t>("A decay", "A", 1);
+    kernel->registerReaction<fusion_t>("B+C->E", "B", "C", "E", 1, 17);
+    kernel->registerReaction<fusion_t>("B+D->A", "B", "D", "A", 1, 17);
+    kernel->registerReaction<conversion_t>("E->A", "E", "A", 1);
+    kernel->registerReaction<conversion_t>("C->D", "C", "D", 1);
 
     auto &&integrator = kernel->createProgram<readdy::model::programs::EulerBDIntegrator>();
     auto &&forces = kernel->createProgram<readdy::model::programs::CalculateForces>();

--- a/kernels/singlecpu/test/SingleCPUTestReactions.cpp
+++ b/kernels/singlecpu/test/SingleCPUTestReactions.cpp
@@ -130,7 +130,7 @@ TEST(SingleCPUTestReactions, TestDecay) {
     kernel->getKernelContext().setTimeStep(1);
     kernel->getKernelContext().setDiffusionConstant("X", .25);
     kernel->getKernelContext().registerDeathReaction("X decay", "X", 1);
-    kernel->getKernelContext().registerFissionReaction("X fission", "X", "X", "X", .3, .5);
+    kernel->getKernelContext().registerFissionReaction("X fission", "X", "X", "X", .5, .3);
 
     auto &&integrator = kernel->createProgram<readdy::model::programs::EulerBDIntegrator>();
     auto &&forces = kernel->createProgram<readdy::model::programs::CalculateForces>();

--- a/readdy/main/Simulation.cpp
+++ b/readdy/main/Simulation.cpp
@@ -73,6 +73,9 @@ namespace readdy {
                 forces->execute();
                 pimpl->kernel->evaluateObservables(t + 1);
             }
+
+            neighborList->setAction(rmp::UpdateNeighborList::Action::clear);
+            neighborList->execute();
         }
     }
 

--- a/readdy/main/Simulation.cpp
+++ b/readdy/main/Simulation.cpp
@@ -213,7 +213,7 @@ namespace readdy {
 
     const boost::uuids::uuid &
     Simulation::registerConversionReaction(const std::string &name, const std::string &from, const std::string &to,
-                                           const double &rate) {
+                                           const double rate) {
         ensureKernelSelected();
         namespace rmr = readdy::model::reactions;
         auto reaction = pimpl->kernel->createConversionReaction(name, from, to, rate);
@@ -222,8 +222,8 @@ namespace readdy {
 
     const boost::uuids::uuid &
     Simulation::registerEnzymaticReaction(const std::string &name, const std::string &catalyst, const std::string &from,
-                                          const std::string &to, const double &rate,
-                                          const double &eductDistance) {
+                                          const std::string &to, const double rate,
+                                          const double eductDistance) {
         ensureKernelSelected();
         namespace rmr = readdy::model::reactions;
         auto reaction = pimpl->kernel->createEnzymaticReaction(name, catalyst, from, to, rate, eductDistance);
@@ -233,8 +233,8 @@ namespace readdy {
     const boost::uuids::uuid &
     Simulation::registerFissionReaction(const std::string &name, const std::string &from, const std::string &to1,
                                         const std::string &to2,
-                                        const double &rate, const double productDistance, const double &weight1,
-                                        const double &weight2) {
+                                        const double rate, const double productDistance, const double weight1,
+                                        const double weight2) {
         ensureKernelSelected();
         auto reaction = pimpl->kernel->createFissionReaction(name, from, to1, to2, rate, productDistance, weight1, weight2);
         return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));
@@ -242,15 +242,15 @@ namespace readdy {
 
     const boost::uuids::uuid &
     Simulation::registerFusionReaction(const std::string &name, const std::string &from1, const std::string &from2,
-                                       const std::string &to, const double &rate,
-                                       const double &eductDistance, const double &weight1, const double &weight2) {
+                                       const std::string &to, const double rate,
+                                       const double eductDistance, const double weight1, const double weight2) {
         ensureKernelSelected();
         auto reaction = pimpl->kernel->createFusionReaction(name, from1, from2, to, rate, eductDistance, weight1, weight2);
         return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));
     }
 
     const boost::uuids::uuid &
-    Simulation::registerDecayReaction(const std::string &name, const std::string &particleType, const double &rate) {
+    Simulation::registerDecayReaction(const std::string &name, const std::string &particleType, const double rate) {
         ensureKernelSelected();
         auto reaction = pimpl->kernel->createDecayReaction(name, particleType, rate);
         return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));

--- a/readdy/main/Simulation.cpp
+++ b/readdy/main/Simulation.cpp
@@ -3,335 +3,362 @@
 //
 #include <readdy/Simulation.h>
 #include <readdy/plugin/KernelProvider.h>
-#include <readdy/model/programs/Programs.h>
-#include <readdy/model/potentials/PotentialsOrder2.h>
-#include <readdy/model/potentials/PotentialsOrder1.h>
 #include <readdy/kernel/singlecpu/SingleCPUKernel.h>
 
-using namespace readdy;
+namespace rmr = readdy::model::reactions;
+namespace rmp = readdy::model::programs;
 
-double Simulation::getKBT() const {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelContext().getKBT();
+namespace readdy {
+    double Simulation::getKBT() const {
+        ensureKernelSelected();
+        return pimpl->kernel->getKernelContext().getKBT();
 
-}
-
-void Simulation::setKBT(double kBT) {
-    ensureKernelSelected();
-    pimpl->kernel->getKernelContext().setKBT(kBT);
-
-}
-
-void Simulation::setBoxSize(const readdy::model::Vec3 &boxSize) {
-    setBoxSize(boxSize[0], boxSize[1], boxSize[2]);
-}
-
-void Simulation::setPeriodicBoundary(std::array<bool, 3> periodic) {
-    ensureKernelSelected();
-    pimpl->kernel->getKernelContext().setPeriodicBoundary(periodic[0], periodic[1], periodic[2]);
-
-}
-
-Simulation::Simulation() : pimpl(std::make_unique<Simulation::Impl>()) { }
-
-readdy::model::Vec3 Simulation::getBoxSize() const {
-    ensureKernelSelected();
-    return readdy::model::Vec3(pimpl->kernel->getKernelContext().getBoxSize());
-
-}
-
-std::array<bool, 3> Simulation::getPeriodicBoundary() const {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelContext().getPeriodicBoundary();
-}
-
-void Simulation::run(const readdy::model::time_step_type steps, const double timeStep) {
-    namespace rmp = readdy::model::programs; 
-    ensureKernelSelected();
-    {
-        BOOST_LOG_TRIVIAL(debug) << "available programs: ";
-        for (auto &&p : pimpl->kernel->getAvailablePrograms()) {
-            BOOST_LOG_TRIVIAL(debug) << "\t" << p;
-        }
-    }
-    pimpl->kernel->getKernelContext().setTimeStep(timeStep);
-    {
-        auto &&integrator = pimpl->kernel->createProgram<rmp::EulerBDIntegrator>();
-        auto &&forces = pimpl->kernel->createProgram<rmp::CalculateForces>();
-        auto &&neighborList = pimpl->kernel->createProgram<rmp::UpdateNeighborList>();
-        auto &&reactionsProgram = pimpl->kernel->createProgram<rmp::reactions::UncontrolledApproximation>();
-        pimpl->kernel->getKernelContext().configure();
-
-        neighborList->execute();
-        forces->execute();
-        pimpl->kernel->evaluateObservables(0);
-        for (readdy::model::time_step_type &&t = 0; t < steps; ++t) {
-            integrator->execute();
-            neighborList->execute();
-            forces->execute();
-
-            reactionsProgram->execute();
-            neighborList->execute();
-            forces->execute();
-            pimpl->kernel->evaluateObservables(t+1);
-        }
-    }
-}
-
-void Simulation::setKernel(const std::string &kernel) {
-    if (isKernelSelected()) {
-        BOOST_LOG_TRIVIAL(debug) << "replacing kernel \"" << pimpl->kernel->getName() << "\" with \"" << kernel << "\"";
-    }
-    pimpl->kernel = readdy::plugin::KernelProvider::getInstance().create(kernel);
-}
-
-bool Simulation::isKernelSelected() const {
-    return pimpl->kernel ? true : false;
-}
-
-const std::string &Simulation::getSelectedKernelType() const {
-    ensureKernelSelected();
-    return pimpl->kernel->getName();
-}
-
-void Simulation::addParticle(double x, double y, double z, const std::string &type) {
-    ensureKernelSelected();
-    const auto &&s = getBoxSize();
-    if (fabs(x) <= .5*s[0] && fabs(y) <= .5*s[1] && fabs(z) <= .5*s[2]) {
-        readdy::model::Particle p{x, y, z, pimpl->kernel->getKernelContext().getParticleTypeID(type)};
-        pimpl->kernel->getKernelStateModel().addParticle(p);
-    } else {
-        BOOST_LOG_TRIVIAL(error) << "particle position was not in bounds of the simulation box!";
     }
 
-}
+    void Simulation::setKBT(double kBT) {
+        ensureKernelSelected();
+        pimpl->kernel->getKernelContext().setKBT(kBT);
 
-void Simulation::registerParticleType(const std::string &name, const double diffusionCoefficient, const double radius) {
-    ensureKernelSelected();
-    pimpl->kernel->getKernelContext().setDiffusionConstant(name, diffusionCoefficient);
-    pimpl->kernel->getKernelContext().setParticleRadius(name, radius);
-}
-
-const std::vector<readdy::model::Vec3> Simulation::getAllParticlePositions() const {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelStateModel().getParticlePositions();
-}
-
-void Simulation::registerPotentialOrder1(readdy::model::potentials::PotentialOrder1 const* const ptr, const std::string &type) {
-    ensureKernelSelected();
-    pimpl->kernel->getKernelContext().registerOrder1Potential(ptr, type);
-}
-
-void Simulation::deregisterPotential(const boost::uuids::uuid &uuid) {
-    pimpl->kernel->getKernelContext().deregisterPotential(uuid);
-};
-
-boost::uuids::uuid Simulation::registerHarmonicRepulsionPotential(std::string particleTypeA, std::string particleTypeB, double forceConstant) {
-    ensureKernelSelected();
-    auto ptr = pimpl->kernel->createPotentialAs<readdy::model::potentials::HarmonicRepulsion>();
-    ptr->setForceConstant(forceConstant);
-    return pimpl->kernel->getKernelContext().registerOrder2Potential(ptr.get(), particleTypeA, particleTypeB);
-}
-
-boost::uuids::uuid Simulation::registerWeakInteractionPiecewiseHarmonicPotential(std::string particleTypeA, std::string particleTypeB, double forceConstant, double desiredParticleDistance,
-                                                                                 double depth, double noInteractionDistance) {
-    ensureKernelSelected();
-    auto ptr = pimpl->kernel->createPotentialAs<readdy::model::potentials::WeakInteractionPiecewiseHarmonic>();
-    ptr->setForceConstant(forceConstant);
-    ptr->setDesiredParticleDistance(desiredParticleDistance);
-    ptr->setDepthAtDesiredDistance(depth);
-    ptr->setNoInteractionDistance(noInteractionDistance);
-    return pimpl->kernel->getKernelContext().registerOrder2Potential(ptr.get(), particleTypeA, particleTypeB);
-}
-
-boost::uuids::uuid Simulation::registerBoxPotential(std::string particleType, double forceConstant, readdy::model::Vec3 origin, readdy::model::Vec3 extent, bool considerParticleRadius) {
-    ensureKernelSelected();
-    auto ptr = pimpl->kernel->createPotentialAs<readdy::model::potentials::CubePotential>();
-    ptr->setOrigin(origin);
-    ptr->setExtent(extent);
-    ptr->setConsiderParticleRadius(considerParticleRadius);
-    ptr->setForceConstant(forceConstant);
-    return pimpl->kernel->getKernelContext().registerOrder1Potential(ptr.get(), particleType);
-}
-
-void Simulation::registerPotentialOrder2(model::potentials::PotentialOrder2 const* const ptr, const std::string &type1, const std::string &type2) {
-    ensureKernelSelected();
-    pimpl->kernel->getKernelContext().registerOrder2Potential(ptr, type1, type2);
-}
-
-void Simulation::ensureKernelSelected() const {
-    if (!isKernelSelected()) {
-        throw NoKernelSelectedException("No kernel was selected!");
-    }
-}
-
-void Simulation::setBoxSize(double dx, double dy, double dz) {
-    ensureKernelSelected();
-    pimpl->kernel->getKernelContext().setBoxSize(dx, dy, dz);
-}
-
-boost::uuids::uuid Simulation::registerObservable(readdy::model::ObservableBase &observable) {
-    ensureKernelSelected();
-    boost::uuids::random_generator uuid_gen;
-    auto uuid = uuid_gen();
-    auto&& connection = pimpl->kernel->connectObservable(&observable);
-    pimpl->observableConnections.emplace(uuid, std::move(connection));
-    return uuid;
-}
-
-void Simulation::deregisterObservable(const boost::uuids::uuid uuid) {
-    pimpl->observableConnections.erase(uuid);
-    if(pimpl->observables.find(uuid) != pimpl->observables.end()) {
-        pimpl->observables.erase(uuid);
-    }
-}
-
-std::vector<std::string> Simulation::getAvailableObservables() {
-    ensureKernelSelected();
-    // TODO compile a list of observables
-    return {"hallo"};
-}
-
-
-Simulation &Simulation::operator=(Simulation &&rhs) = default;
-
-Simulation::Simulation(Simulation &&rhs) = default;
-
-Simulation::~Simulation() = default;
-
-const boost::uuids::uuid &Simulation::registerConversionReaction(const std::string &name, const std::string &from, const std::string &to, const double &rate) {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelContext().registerConversionReaction(name, from, to, rate);
-}
-
-const boost::uuids::uuid &Simulation::registerEnzymaticReaction(const std::string &name, const std::string &catalyst, const std::string &from, const std::string &to, const double &rate,
-                                                                const double &eductDistance) {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelContext().registerEnzymaticReaction(name, catalyst, from, to, rate, eductDistance);
-}
-
-const boost::uuids::uuid &Simulation::registerFissionReaction(const std::string &name, const std::string &from, const std::string &to1, const std::string &to2,
-                                                              const double &rate, const double productDistance, const double &weight1, const double &weight2) {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelContext().registerFissionReaction(name, from, to1, to2, productDistance, rate, weight1, weight2);
-}
-
-const boost::uuids::uuid &Simulation::registerFusionReaction(const std::string &name, const std::string &from1, const std::string &from2, const std::string &to, const double &rate,
-                                                             const double &eductDistance, const double &weight1, const double &weight2) {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelContext().registerFusionReaction(name, from1, from2, to, rate, eductDistance, weight1, weight2);
-}
-
-const boost::uuids::uuid &Simulation::registerDeathReaction(const std::string &name, const std::string &particleType, const double &rate) {
-    ensureKernelSelected();
-    return pimpl->kernel->getKernelContext().registerDeathReaction(name, particleType, rate);
-}
-
-std::vector<readdy::model::Vec3> Simulation::getParticlePositions(std::string type) {
-    unsigned int typeId = pimpl->kernel->getKernelContext().getParticleTypeID(type);
-    const auto particles = pimpl->kernel->getKernelStateModel().getParticles();
-    std::vector<readdy::model::Vec3> positions;
-    for(auto&& p : particles) {
-        if(p.getType() == typeId) {
-            positions.push_back(p.getPos());
-        }
-    }
-    return positions;
-}
-
-double Simulation::getRecommendedTimeStep(unsigned int N) const {
-    double tau_R = 0;
-
-    readdy::kernel::singlecpu::SingleCPUKernel k;
-
-    const auto& context = pimpl->kernel->getKernelContext();
-    double kbt = context.getKBT();
-    double kReactionMax = 0;
-
-    for(auto&& reactionO1 : context.getAllOrder1Reactions()) {
-        kReactionMax = std::max(kReactionMax, reactionO1->getRate());
-    }
-    for(auto&& reactionO2 : context.getAllOrder2Reactions()) {
-        kReactionMax = std::max(kReactionMax, reactionO2->getRate());
     }
 
-    double tDMin = 0;
-    std::unordered_map<unsigned int, double> fMaxes;
-    for(auto&& pI : context.getAllRegisteredParticleTypes()) {
-        double D = context.getDiffusionConstant(pI);
-        double tD = 0;
-        double xi = 0; // 1/(beta*Fmax)
-        double fMax = 0;
-        double rMin = std::numeric_limits<double>::max();
+    void Simulation::setBoxSize(const readdy::model::Vec3 &boxSize) {
+        setBoxSize(boxSize[0], boxSize[1], boxSize[2]);
+    }
 
-        for (auto &&reaction : context.getOrder1Reactions(pI)) {
-            if (reaction->getNProducts() == 2 && reaction->getProductDistance() > 0) {
-                rMin = std::min(rMin, reaction->getProductDistance());
+    void Simulation::setPeriodicBoundary(std::array<bool, 3> periodic) {
+        ensureKernelSelected();
+        pimpl->kernel->getKernelContext().setPeriodicBoundary(periodic[0], periodic[1], periodic[2]);
+
+    }
+
+    Simulation::Simulation() : pimpl(std::make_unique<Simulation::Impl>()) {}
+
+    readdy::model::Vec3 Simulation::getBoxSize() const {
+        ensureKernelSelected();
+        return readdy::model::Vec3(pimpl->kernel->getKernelContext().getBoxSize());
+
+    }
+
+    std::array<bool, 3> Simulation::getPeriodicBoundary() const {
+        ensureKernelSelected();
+        return pimpl->kernel->getKernelContext().getPeriodicBoundary();
+    }
+
+    void Simulation::run(const readdy::model::time_step_type steps, const double timeStep) {
+        ensureKernelSelected();
+        {
+            BOOST_LOG_TRIVIAL(debug) << "available programs: ";
+            for (auto &&p : pimpl->kernel->getAvailablePrograms()) {
+                BOOST_LOG_TRIVIAL(debug) << "\t" << p;
             }
         }
+        pimpl->kernel->getKernelContext().setTimeStep(timeStep);
+        {
+            auto &&integrator = pimpl->kernel->createProgram<rmp::EulerBDIntegrator>();
+            auto &&forces = pimpl->kernel->createProgram<rmp::CalculateForces>();
+            auto &&neighborList = pimpl->kernel->createProgram<rmp::UpdateNeighborList>();
+            auto &&reactionsProgram = pimpl->kernel->createProgram<rmp::reactions::UncontrolledApproximation>();
+            pimpl->kernel->getKernelContext().configure();
 
-        for (auto &&pot : context.getOrder1Potentials(pI)) {
-            fMax = std::max(pot->getMaximalForce(kbt), fMax);
-            if(pot->getRelevantLengthScale() > 0) {
-                rMin = std::min(rMin, pot->getRelevantLengthScale());
+            neighborList->execute();
+            forces->execute();
+            pimpl->kernel->evaluateObservables(0);
+            for (readdy::model::time_step_type &&t = 0; t < steps; ++t) {
+                integrator->execute();
+                neighborList->execute();
+                forces->execute();
+
+                reactionsProgram->execute();
+                neighborList->execute();
+                forces->execute();
+                pimpl->kernel->evaluateObservables(t + 1);
             }
         }
+    }
 
-        for (auto &&pJ : context.getAllRegisteredParticleTypes()) {
+    void Simulation::setKernel(const std::string &kernel) {
+        if (isKernelSelected()) {
+            BOOST_LOG_TRIVIAL(debug) << "replacing kernel \"" << pimpl->kernel->getName() << "\" with \"" << kernel
+                                     << "\"";
+        }
+        pimpl->kernel = readdy::plugin::KernelProvider::getInstance().create(kernel);
+    }
 
-            for (auto &&reaction : context.getOrder2Reactions(pI, pJ)) {
-                if (reaction->getEductDistance() > 0) {
-                    rMin = std::min(rMin, reaction->getEductDistance());
-                }
+    bool Simulation::isKernelSelected() const {
+        return pimpl->kernel ? true : false;
+    }
+
+    const std::string &Simulation::getSelectedKernelType() const {
+        ensureKernelSelected();
+        return pimpl->kernel->getName();
+    }
+
+    void Simulation::addParticle(double x, double y, double z, const std::string &type) {
+        ensureKernelSelected();
+        const auto &&s = getBoxSize();
+        if (fabs(x) <= .5 * s[0] && fabs(y) <= .5 * s[1] && fabs(z) <= .5 * s[2]) {
+            readdy::model::Particle p{x, y, z, pimpl->kernel->getKernelContext().getParticleTypeID(type)};
+            pimpl->kernel->getKernelStateModel().addParticle(p);
+        } else {
+            BOOST_LOG_TRIVIAL(error) << "particle position was not in bounds of the simulation box!";
+        }
+
+    }
+
+    void
+    Simulation::registerParticleType(const std::string &name, const double diffusionCoefficient, const double radius) {
+        ensureKernelSelected();
+        pimpl->kernel->getKernelContext().setDiffusionConstant(name, diffusionCoefficient);
+        pimpl->kernel->getKernelContext().setParticleRadius(name, radius);
+    }
+
+    const std::vector<readdy::model::Vec3> Simulation::getAllParticlePositions() const {
+        ensureKernelSelected();
+        return pimpl->kernel->getKernelStateModel().getParticlePositions();
+    }
+
+    void Simulation::registerPotentialOrder1(readdy::model::potentials::PotentialOrder1 const *const ptr,
+                                             const std::string &type) {
+        ensureKernelSelected();
+        pimpl->kernel->getKernelContext().registerOrder1Potential(ptr, type);
+    }
+
+    void Simulation::deregisterPotential(const boost::uuids::uuid &uuid) {
+        pimpl->kernel->getKernelContext().deregisterPotential(uuid);
+    };
+
+    boost::uuids::uuid
+    Simulation::registerHarmonicRepulsionPotential(std::string particleTypeA, std::string particleTypeB,
+                                                   double forceConstant) {
+        ensureKernelSelected();
+        auto ptr = pimpl->kernel->createPotentialAs<readdy::model::potentials::HarmonicRepulsion>();
+        ptr->setForceConstant(forceConstant);
+        return pimpl->kernel->getKernelContext().registerOrder2Potential(ptr.get(), particleTypeA, particleTypeB);
+    }
+
+    boost::uuids::uuid
+    Simulation::registerWeakInteractionPiecewiseHarmonicPotential(std::string particleTypeA, std::string particleTypeB,
+                                                                  double forceConstant, double desiredParticleDistance,
+                                                                  double depth, double noInteractionDistance) {
+        ensureKernelSelected();
+        auto ptr = pimpl->kernel->createPotentialAs<readdy::model::potentials::WeakInteractionPiecewiseHarmonic>();
+        ptr->setForceConstant(forceConstant);
+        ptr->setDesiredParticleDistance(desiredParticleDistance);
+        ptr->setDepthAtDesiredDistance(depth);
+        ptr->setNoInteractionDistance(noInteractionDistance);
+        return pimpl->kernel->getKernelContext().registerOrder2Potential(ptr.get(), particleTypeA, particleTypeB);
+    }
+
+    boost::uuids::uuid
+    Simulation::registerBoxPotential(std::string particleType, double forceConstant, readdy::model::Vec3 origin,
+                                     readdy::model::Vec3 extent, bool considerParticleRadius) {
+        ensureKernelSelected();
+        auto ptr = pimpl->kernel->createPotentialAs<readdy::model::potentials::CubePotential>();
+        ptr->setOrigin(origin);
+        ptr->setExtent(extent);
+        ptr->setConsiderParticleRadius(considerParticleRadius);
+        ptr->setForceConstant(forceConstant);
+        return pimpl->kernel->getKernelContext().registerOrder1Potential(ptr.get(), particleType);
+    }
+
+    void
+    Simulation::registerPotentialOrder2(model::potentials::PotentialOrder2 const *const ptr, const std::string &type1,
+                                        const std::string &type2) {
+        ensureKernelSelected();
+        pimpl->kernel->getKernelContext().registerOrder2Potential(ptr, type1, type2);
+    }
+
+    void Simulation::ensureKernelSelected() const {
+        if (!isKernelSelected()) {
+            throw NoKernelSelectedException("No kernel was selected!");
+        }
+    }
+
+    void Simulation::setBoxSize(double dx, double dy, double dz) {
+        ensureKernelSelected();
+        pimpl->kernel->getKernelContext().setBoxSize(dx, dy, dz);
+    }
+
+    boost::uuids::uuid Simulation::registerObservable(readdy::model::ObservableBase &observable) {
+        ensureKernelSelected();
+        boost::uuids::random_generator uuid_gen;
+        auto uuid = uuid_gen();
+        auto &&connection = pimpl->kernel->connectObservable(&observable);
+        pimpl->observableConnections.emplace(uuid, std::move(connection));
+        return uuid;
+    }
+
+    void Simulation::deregisterObservable(const boost::uuids::uuid uuid) {
+        pimpl->observableConnections.erase(uuid);
+        if (pimpl->observables.find(uuid) != pimpl->observables.end()) {
+            pimpl->observables.erase(uuid);
+        }
+    }
+
+    std::vector<std::string> Simulation::getAvailableObservables() {
+        ensureKernelSelected();
+        // TODO compile a list of observables
+        return {"hallo"};
+    }
+
+
+    Simulation &Simulation::operator=(Simulation &&rhs) = default;
+
+    Simulation::Simulation(Simulation &&rhs) = default;
+
+    Simulation::~Simulation() = default;
+
+    const boost::uuids::uuid &
+    Simulation::registerConversionReaction(const std::string &name, const std::string &from, const std::string &to,
+                                           const double &rate) {
+        ensureKernelSelected();
+        namespace rmr = readdy::model::reactions;
+        auto reaction = pimpl->kernel->createConversionReaction(name, from, to, rate);
+        return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));
+    }
+
+    const boost::uuids::uuid &
+    Simulation::registerEnzymaticReaction(const std::string &name, const std::string &catalyst, const std::string &from,
+                                          const std::string &to, const double &rate,
+                                          const double &eductDistance) {
+        ensureKernelSelected();
+        namespace rmr = readdy::model::reactions;
+        auto reaction = pimpl->kernel->createEnzymaticReaction(name, catalyst, from, to, rate, eductDistance);
+        return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));
+    }
+
+    const boost::uuids::uuid &
+    Simulation::registerFissionReaction(const std::string &name, const std::string &from, const std::string &to1,
+                                        const std::string &to2,
+                                        const double &rate, const double productDistance, const double &weight1,
+                                        const double &weight2) {
+        ensureKernelSelected();
+        auto reaction = pimpl->kernel->createFissionReaction(name, from, to1, to2, rate, productDistance, weight1, weight2);
+        return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));
+    }
+
+    const boost::uuids::uuid &
+    Simulation::registerFusionReaction(const std::string &name, const std::string &from1, const std::string &from2,
+                                       const std::string &to, const double &rate,
+                                       const double &eductDistance, const double &weight1, const double &weight2) {
+        ensureKernelSelected();
+        auto reaction = pimpl->kernel->createFusionReaction(name, from1, from2, to, rate, eductDistance, weight1, weight2);
+        return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));
+    }
+
+    const boost::uuids::uuid &
+    Simulation::registerDecayReaction(const std::string &name, const std::string &particleType, const double &rate) {
+        ensureKernelSelected();
+        auto reaction = pimpl->kernel->createDecayReaction(name, particleType, rate);
+        return pimpl->kernel->getKernelContext().registerReaction(std::move(reaction));
+    }
+
+    std::vector<readdy::model::Vec3> Simulation::getParticlePositions(std::string type) {
+        unsigned int typeId = pimpl->kernel->getKernelContext().getParticleTypeID(type);
+        const auto particles = pimpl->kernel->getKernelStateModel().getParticles();
+        std::vector<readdy::model::Vec3> positions;
+        for (auto &&p : particles) {
+            if (p.getType() == typeId) {
+                positions.push_back(p.getPos());
+            }
+        }
+        return positions;
+    }
+
+    double Simulation::getRecommendedTimeStep(unsigned int N) const {
+        double tau_R = 0;
+
+        readdy::kernel::singlecpu::SingleCPUKernel k;
+
+        const auto &context = pimpl->kernel->getKernelContext();
+        double kbt = context.getKBT();
+        double kReactionMax = 0;
+
+        for (auto &&reactionO1 : context.getAllOrder1Reactions()) {
+            kReactionMax = std::max(kReactionMax, reactionO1->getRate());
+        }
+        for (auto &&reactionO2 : context.getAllOrder2Reactions()) {
+            kReactionMax = std::max(kReactionMax, reactionO2->getRate());
+        }
+
+        double tDMin = 0;
+        std::unordered_map<unsigned int, double> fMaxes;
+        for (auto &&pI : context.getAllRegisteredParticleTypes()) {
+            double D = context.getDiffusionConstant(pI);
+            double tD = 0;
+            double xi = 0; // 1/(beta*Fmax)
+            double fMax = 0;
+            double rMin = std::numeric_limits<double>::max();
+
+            for (auto &&reaction : context.getOrder1Reactions(pI)) {
                 if (reaction->getNProducts() == 2 && reaction->getProductDistance() > 0) {
                     rMin = std::min(rMin, reaction->getProductDistance());
                 }
             }
 
-            for (auto &&pot : context.getOrder2Potentials(pI, pJ)) {
-                if (pot->getCutoffRadius() > 0) {
-                    rMin = std::min(rMin, pot->getCutoffRadius());
-                    fMax = std::max(pot->getMaximalForce(kbt), fMax);
-                } else {
-                    BOOST_LOG_TRIVIAL(warning) << "Discovered potential with cutoff radius 0.";
+            for (auto &&pot : context.getOrder1Potentials(pI)) {
+                fMax = std::max(pot->getMaximalForce(kbt), fMax);
+                if (pot->getRelevantLengthScale() > 0) {
+                    rMin = std::min(rMin, pot->getRelevantLengthScale());
                 }
             }
+
+            for (auto &&pJ : context.getAllRegisteredParticleTypes()) {
+
+                for (auto &&reaction : context.getOrder2Reactions(pI, pJ)) {
+                    if (reaction->getEductDistance() > 0) {
+                        rMin = std::min(rMin, reaction->getEductDistance());
+                    }
+                    if (reaction->getNProducts() == 2 && reaction->getProductDistance() > 0) {
+                        rMin = std::min(rMin, reaction->getProductDistance());
+                    }
+                }
+
+                for (auto &&pot : context.getOrder2Potentials(pI, pJ)) {
+                    if (pot->getCutoffRadius() > 0) {
+                        rMin = std::min(rMin, pot->getCutoffRadius());
+                        fMax = std::max(pot->getMaximalForce(kbt), fMax);
+                    } else {
+                        BOOST_LOG_TRIVIAL(warning) << "Discovered potential with cutoff radius 0.";
+                    }
+                }
+            }
+            double rho = rMin / 2;
+            if (fMax > 0) {
+                xi = 1. / (context.getKBT() * fMax);
+                tD = (xi * xi / D) * (1 + rho / xi - sqrt(1 + 2 * rho / xi));
+            } else if (D > 0) {
+                tD = .5 * rho * rho / D;
+            }
+            fMaxes.emplace(pI, fMax);
+            BOOST_LOG_TRIVIAL(trace) << " tau for " << context.getParticleName(pI) << ": " << tD << "( xi = "
+                                     << xi << ", rho=" << rho << ")";
+            if (tDMin == 0) {
+                tDMin = tD;
+            } else {
+                tDMin = std::min(tDMin, tD);
+            }
         }
-        double rho = rMin / 2;
-        if (fMax > 0) {
-            xi = 1. / (context.getKBT() * fMax);
-            tD = (xi * xi / D) * (1 + rho / xi - sqrt(1 + 2 * rho / xi));
-        } else if(D > 0) {
-            tD = .5 * rho * rho / D;
+
+        BOOST_LOG_TRIVIAL(debug)
+            << "Maximal displacement for particle types per time step (stochastic + deterministic): ";
+        for (auto &&pI : context.getAllRegisteredParticleTypes()) {
+            double D = context.getDiffusionConstant(pI);
+            double xmax = sqrt(2 * D * tDMin) + D * kbt * fMaxes[pI] * tDMin;
+            BOOST_LOG_TRIVIAL(debug) << "\t - " << context.getParticleName(pI) << ": " << sqrt(2 * D * tDMin) << " + "
+                                     << D * kbt * fMaxes[pI] * tDMin << " = " << xmax;
         }
-        fMaxes.emplace(pI, fMax);
-        BOOST_LOG_TRIVIAL(trace) << " tau for " << context.getParticleName(pI) << ": " << tD << "( xi = "
-                                 << xi << ", rho=" << rho << ")";
-        if (tDMin == 0) {
-            tDMin = tD;
-        } else {
-            tDMin = std::min(tDMin, tD);
-        }
+
+        if (kReactionMax > 0) tau_R = 1. / kReactionMax;
+
+        double tau = std::max(tau_R, tDMin);
+        if (tau_R > 0) tau = std::min(tau_R, tau);
+        if (tDMin > 0) tau = std::min(tDMin, tau);
+        tau /= (double) N;
+        BOOST_LOG_TRIVIAL(debug) << "Estimated time step: " << tau;
+        return tau;
     }
 
-    BOOST_LOG_TRIVIAL(debug) << "Maximal displacement for particle types per time step (stochastic + deterministic): ";
-    for(auto&& pI : context.getAllRegisteredParticleTypes()) {
-        double D = context.getDiffusionConstant(pI);
-        double xmax = sqrt(2*D*tDMin) + D*kbt*fMaxes[pI]*tDMin;
-        BOOST_LOG_TRIVIAL(debug) << "\t - " << context.getParticleName(pI) << ": " << sqrt(2*D*tDMin) << " + "
-                                 << D*kbt*fMaxes[pI]*tDMin << " = " << xmax;
-    }
+    NoKernelSelectedException::NoKernelSelectedException(const std::string &__arg) : runtime_error(__arg) {};
 
-    if (kReactionMax>0) tau_R  = 1./kReactionMax;
-
-    double tau = std::max(tau_R, tDMin);
-    if(tau_R > 0) tau = std::min(tau_R, tau);
-    if(tDMin > 0) tau = std::min(tDMin, tau);
-    tau /= (double) N;
-    BOOST_LOG_TRIVIAL(debug) << "Estimated time step: " << tau;
-    return tau;
 }
-
-
-NoKernelSelectedException::NoKernelSelectedException(const std::string &__arg) : runtime_error(__arg) { };
-

--- a/readdy/main/Simulation.cpp
+++ b/readdy/main/Simulation.cpp
@@ -210,8 +210,8 @@ const boost::uuids::uuid &Simulation::registerEnzymaticReaction(const std::strin
     return pimpl->kernel->getKernelContext().registerEnzymaticReaction(name, catalyst, from, to, rate, eductDistance);
 }
 
-const boost::uuids::uuid &Simulation::registerFissionReaction(const std::string &name, const std::string &from, const std::string &to1, const std::string &to2, const double productDistance,
-                                                              const double &rate, const double &weight1, const double &weight2) {
+const boost::uuids::uuid &Simulation::registerFissionReaction(const std::string &name, const std::string &from, const std::string &to1, const std::string &to2,
+                                                              const double &rate, const double productDistance, const double &weight1, const double &weight2) {
     ensureKernelSelected();
     return pimpl->kernel->getKernelContext().registerFissionReaction(name, from, to1, to2, productDistance, rate, weight1, weight2);
 }

--- a/readdy/main/model/Kernel.cpp
+++ b/readdy/main/model/Kernel.cpp
@@ -96,6 +96,41 @@ namespace readdy {
             return getPotentialFactory().createPotential(name);
         }
 
+        unsigned int Kernel::getTypeId(const std::string &name) const {
+            return getKernelContext().getTypeMapping().find(name)->second;
+        }
+
+        std::unique_ptr<reactions::Conversion>
+        Kernel::createConversionReaction(const std::string &name, const std::string &from, const std::string &to,
+                                         const double rate) const {
+            return getReactionFactory().createReaction<reactions::Conversion>(name, getTypeId(from), getTypeId(to), rate);
+        }
+
+        std::unique_ptr<reactions::Fusion>
+        Kernel::createFusionReaction(const std::string &name, const std::string &from1, const std::string &from2,
+                                     const std::string &to, const double rate, const double eductDistance,
+                                     const double weight1, const double weight2) const {
+            return getReactionFactory().createReaction<reactions::Fusion>(name, getTypeId(from1), getTypeId(from2), getTypeId(to), rate, eductDistance, weight1, weight2);
+        }
+
+        std::unique_ptr<reactions::Enzymatic>
+        Kernel::createEnzymaticReaction(const std::string &name, const std::string &catalyst, const std::string &from,
+                                         const std::string &to, const double rate, const double eductDistance) const {
+            return getReactionFactory().createReaction<reactions::Enzymatic>(name, getTypeId(catalyst), getTypeId(from), getTypeId(to), rate, eductDistance);
+        }
+
+        std::unique_ptr<reactions::Fission>
+        Kernel::createFissionReaction(const std::string &name, const std::string &from, const std::string &to1,
+                              const std::string &to2, const double rate, const double productDistance,
+                              const double weight1, const double weight2) const {
+            return getReactionFactory().createReaction<reactions::Fission>(name, getTypeId(from), getTypeId(to1), getTypeId(to2), rate, productDistance, weight1, weight2);
+        }
+
+        std::unique_ptr<reactions::Decay>
+        Kernel::createDecayReaction(const std::string &name, const std::string &type, const double rate) const {
+            return getReactionFactory().createReaction<reactions::Decay>(name, getTypeId(type), rate);
+        }
+
 
         Kernel &Kernel::operator=(Kernel &&rhs) = default;
 

--- a/readdy/main/model/KernelContext.cpp
+++ b/readdy/main/model/KernelContext.cpp
@@ -192,7 +192,7 @@ namespace readdy {
             return getParticleRadius(pimpl->typeMapping[type]);
         }
 
-        double KernelContext::getParticleRadius(const unsigned int &type) const {
+        double KernelContext::getParticleRadius(const unsigned int type) const {
             if (pimpl->particleRadii.find(type) == pimpl->particleRadii.end()) {
                 BOOST_LOG_TRIVIAL(warning) << "No particle radius was set for the particle type id " << type
                                            << ", setting r=1";
@@ -305,7 +305,7 @@ namespace readdy {
             return getOrder1Reactions(pimpl->typeMapping[type]);
         }
 
-        const std::vector<reactions::Reaction<1> *> &KernelContext::getOrder1Reactions(const unsigned int &type) const {
+        const std::vector<reactions::Reaction<1> *> &KernelContext::getOrder1Reactions(const unsigned int type) const {
             return readdy::utils::collections::getOrDefault(*reactionOneEductRegistry, type, pimpl->defaultReactionsO1);
         }
 
@@ -315,7 +315,7 @@ namespace readdy {
         }
 
         const std::vector<reactions::Reaction<2> *> &
-        KernelContext::getOrder2Reactions(const unsigned int &type1, const unsigned int &type2) const {
+        KernelContext::getOrder2Reactions(const unsigned int type1, const unsigned int type2) const {
             return readdy::utils::collections::getOrDefault(*reactionTwoEductsRegistry, {type1, type2}, pimpl->defaultReactionsO2);
         }
 

--- a/readdy/main/model/KernelContext.cpp
+++ b/readdy/main/model/KernelContext.cpp
@@ -342,7 +342,7 @@ namespace readdy {
         const boost::uuids::uuid &
         KernelContext::registerFissionReaction(const std::string &name, const std::string &from,
                                                const std::string &to1, const std::string &to2,
-                                               const double productDistance, const double &rate,
+                                               const double &rate, const double productDistance,
                                                const double &weight1, const double &weight2) {
             const auto &idFrom = pimpl->typeMapping[from];
             const auto &idTo1 = pimpl->typeMapping[to1];

--- a/readdy/main/model/KernelContext.cpp
+++ b/readdy/main/model/KernelContext.cpp
@@ -15,7 +15,7 @@ namespace readdy {
     namespace model {
         struct KernelContext::Impl {
             uint typeCounter;
-            std::unordered_map<std::string, uint> typeMapping;
+            std::unordered_map<std::string, unsigned int> typeMapping;
             double kBT = 1;
             std::array<double, 3> box_size{{1, 1, 1}};
             std::array<bool, 3> periodic_boundary{{true, true, true}};
@@ -27,14 +27,7 @@ namespace readdy {
             std::unordered_map<unsigned int, std::vector<std::unique_ptr<potentials::PotentialOrder1>>> internalPotentialO1Registry{};
             std::unordered_map<readdy::util::ParticleTypePair, std::vector<std::unique_ptr<potentials::PotentialOrder2>>, readdy::util::ParticleTypePairHasher> internalPotentialO2Registry{};
 
-            std::unordered_map<unsigned int, std::vector<reactions::Reaction<1> *>> reactionOneEductRegistry{};
-            std::unordered_map<readdy::util::ParticleTypePair, std::vector<reactions::Reaction<2> *>, readdy::util::ParticleTypePairHasher> reactionTwoEductsRegistry{};
-            std::unordered_map<unsigned int, std::vector<std::unique_ptr<reactions::Reaction<1>>>> internalReactionOneEductRegistry{};
-            std::unordered_map<readdy::util::ParticleTypePair, std::vector<std::unique_ptr<reactions::Reaction<2>>>, readdy::util::ParticleTypePairHasher> internalReactionTwoEductsRegistry{};
-
             double timeStep;
-
-            reactions::ReactionFactory const *reactionFactory;
 
             std::function<void(Vec3 &)> fixPositionFun = [](
                     Vec3 &vec) -> void { readdy::model::fixPosition<true, true, true>(vec, 1., 1., 1.); };
@@ -46,6 +39,11 @@ namespace readdy {
                 auto dv = diffFun(lhs, rhs);
                 return dv * dv;
             };
+
+            std::vector<reactions::Reaction<1> *> defaultReactionsO1 {};
+            std::vector<reactions::Reaction<2> *> defaultReactionsO2 {};
+            std::vector<potentials::PotentialOrder1 *> defaultPotentialsO1 {};
+            std::vector<potentials::PotentialOrder2 *> defaultPotentialsO2 {};
 
             void updateDistAndFixPositionFun() {
                 if (periodic_boundary[0]) {
@@ -155,9 +153,7 @@ namespace readdy {
             pimpl->updateDistAndFixPositionFun();
         }
 
-        KernelContext::KernelContext(reactions::ReactionFactory const *const reactionFactory) : pimpl(
-                std::make_unique<KernelContext::Impl>()) {
-            pimpl->reactionFactory = reactionFactory;
+        KernelContext::KernelContext() : pimpl(std::make_unique<KernelContext::Impl>()) {
         }
 
         std::array<double, 3> &KernelContext::getBoxSize() const {
@@ -244,7 +240,7 @@ namespace readdy {
 
         const std::vector<potentials::PotentialOrder2 *> &
         KernelContext::getOrder2Potentials(const unsigned int type1, const unsigned int type2) const {
-            return pimpl->potentialO2Registry[{type1, type2}];
+            return readdy::utils::collections::getOrDefault(pimpl->potentialO2Registry, {type1, type2}, pimpl->defaultPotentialsO2);
         }
 
         std::vector<std::tuple<unsigned int, unsigned int>>
@@ -276,7 +272,7 @@ namespace readdy {
         }
 
         std::vector<potentials::PotentialOrder1 *> KernelContext::getOrder1Potentials(const unsigned int type) const {
-            return pimpl->potentialO1Registry[type];
+            return readdy::utils::collections::getOrDefault(pimpl->potentialO1Registry, type, pimpl->defaultPotentialsO1);
         }
 
         std::unordered_set<unsigned int> KernelContext::getAllOrder1RegisteredPotentialTypes() const {
@@ -305,87 +301,12 @@ namespace readdy {
             }
         }
 
-        const boost::uuids::uuid &
-        KernelContext::registerConversionReaction(const std::string &name, const std::string &from,
-                                                  const std::string &to, const double &rate) {
-            const auto &idFrom = pimpl->typeMapping[from];
-            const auto &idTo = pimpl->typeMapping[to];
-            if (pimpl->internalReactionOneEductRegistry.find(idFrom) == pimpl->internalReactionOneEductRegistry.end()) {
-                pimpl->internalReactionOneEductRegistry.emplace(idFrom,
-                                                                std::vector<std::unique_ptr<reactions::Reaction<1>>>());
-            }
-            pimpl->internalReactionOneEductRegistry[idFrom].push_back(
-                    pimpl->reactionFactory->createReaction<reactions::Conversion>(name, idFrom, idTo, rate)
-            );
-            return pimpl->internalReactionOneEductRegistry[idFrom].back()->getId();
-        }
-
-        const boost::uuids::uuid &
-        KernelContext::registerEnzymaticReaction(const std::string &name, const std::string &catalyst,
-                                                 const std::string &from, const std::string &to,
-                                                 const double &rate, const double &eductDistance) {
-            const auto &idFrom = pimpl->typeMapping[from];
-            const auto &idTo = pimpl->typeMapping[to];
-            const auto &idCat = pimpl->typeMapping[catalyst];
-            const readdy::util::ParticleTypePair pp{idFrom, idCat};
-            if (pimpl->internalReactionTwoEductsRegistry.find(pp) == pimpl->internalReactionTwoEductsRegistry.end()) {
-                pimpl->internalReactionTwoEductsRegistry.emplace(pp,
-                                                                 std::vector<std::unique_ptr<reactions::Reaction<2>>>());
-            }
-            pimpl->internalReactionTwoEductsRegistry[pp].push_back(
-                    pimpl->reactionFactory->createReaction<reactions::Enzymatic>(name, idCat, idFrom, idTo, rate,
-                                                                                 eductDistance)
-            );
-            return pimpl->internalReactionTwoEductsRegistry[pp].back()->getId();
-        }
-
-        const boost::uuids::uuid &
-        KernelContext::registerFissionReaction(const std::string &name, const std::string &from,
-                                               const std::string &to1, const std::string &to2,
-                                               const double &rate, const double productDistance,
-                                               const double &weight1, const double &weight2) {
-            const auto &idFrom = pimpl->typeMapping[from];
-            const auto &idTo1 = pimpl->typeMapping[to1];
-            const auto &idTo2 = pimpl->typeMapping[to2];
-            if (pimpl->internalReactionOneEductRegistry.find(idFrom) == pimpl->internalReactionOneEductRegistry.end()) {
-                pimpl->internalReactionOneEductRegistry.emplace(idFrom,
-                                                                std::vector<std::unique_ptr<reactions::Reaction<1>>>());
-            }
-            pimpl->internalReactionOneEductRegistry[idFrom].push_back(
-                    pimpl->reactionFactory->createReaction<reactions::Fission>(
-                            name, idFrom, idTo1, idTo2, productDistance, rate, weight1, weight2
-                    )
-            );
-            return pimpl->internalReactionOneEductRegistry[idFrom].back()->getId();
-        }
-
-        const boost::uuids::uuid &
-        KernelContext::registerFusionReaction(const std::string &name, const std::string &from1,
-                                              const std::string &from2, const std::string &to,
-                                              const double &rate, const double &eductDistance,
-                                              const double &weight1, const double &weight2) {
-            const auto &idFrom1 = pimpl->typeMapping[from1];
-            const auto &idFrom2 = pimpl->typeMapping[from2];
-            const auto &idTo = pimpl->typeMapping[to];
-            const readdy::util::ParticleTypePair pp{idFrom1, idFrom2};
-            if (pimpl->internalReactionTwoEductsRegistry.find(pp) == pimpl->internalReactionTwoEductsRegistry.end()) {
-                pimpl->internalReactionTwoEductsRegistry.emplace(pp,
-                                                                 std::vector<std::unique_ptr<reactions::Reaction<2>>>());
-            }
-            pimpl->internalReactionTwoEductsRegistry[pp].push_back(
-                    pimpl->reactionFactory->createReaction<reactions::Fusion>(
-                            name, idFrom1, idFrom2, idTo, rate, eductDistance, weight1, weight2
-                    )
-            );
-            return pimpl->internalReactionTwoEductsRegistry[pp].back()->getId();
-        }
-
         const std::vector<reactions::Reaction<1> *> &KernelContext::getOrder1Reactions(const std::string &type) const {
             return getOrder1Reactions(pimpl->typeMapping[type]);
         }
 
         const std::vector<reactions::Reaction<1> *> &KernelContext::getOrder1Reactions(const unsigned int &type) const {
-            return pimpl->reactionOneEductRegistry[type];
+            return readdy::utils::collections::getOrDefault(*reactionOneEductRegistry, type, pimpl->defaultReactionsO1);
         }
 
         const std::vector<reactions::Reaction<2> *> &
@@ -395,12 +316,12 @@ namespace readdy {
 
         const std::vector<reactions::Reaction<2> *> &
         KernelContext::getOrder2Reactions(const unsigned int &type1, const unsigned int &type2) const {
-            return pimpl->reactionTwoEductsRegistry[{type1, type2}];
+            return readdy::utils::collections::getOrDefault(*reactionTwoEductsRegistry, {type1, type2}, pimpl->defaultReactionsO2);
         }
 
         const std::vector<const reactions::Reaction<1> *> KernelContext::getAllOrder1Reactions() const {
             auto result = std::vector<const reactions::Reaction<1> *>();
-            for (const auto &mapEntry : pimpl->internalReactionOneEductRegistry) {
+            for (const auto &mapEntry : *internalReactionOneEductRegistry) {
                 for (const auto &reaction : mapEntry.second) {
                     result.push_back(reaction.get());
                 }
@@ -409,7 +330,7 @@ namespace readdy {
         }
 
         const reactions::Reaction<1> *const KernelContext::getReactionOrder1WithName(const std::string &name) const {
-            for (const auto &mapEntry : pimpl->internalReactionOneEductRegistry) {
+            for (const auto &mapEntry : *internalReactionOneEductRegistry) {
                 for (const auto &reaction : mapEntry.second) {
                     if (reaction->getName() == name) return reaction.get();
                 }
@@ -420,7 +341,7 @@ namespace readdy {
 
         const std::vector<const reactions::Reaction<2> *> KernelContext::getAllOrder2Reactions() const {
             auto result = std::vector<const reactions::Reaction<2> *>();
-            for (const auto &mapEntry : pimpl->internalReactionTwoEductsRegistry) {
+            for (const auto &mapEntry : *internalReactionTwoEductsRegistry) {
                 for (const auto &reaction : mapEntry.second) {
                     result.push_back(reaction.get());
                 }
@@ -429,7 +350,7 @@ namespace readdy {
         }
 
         const reactions::Reaction<2> *const KernelContext::getReactionOrder2WithName(const std::string &name) const {
-            for (const auto &mapEntry : pimpl->internalReactionTwoEductsRegistry) {
+            for (const auto &mapEntry : *internalReactionTwoEductsRegistry) {
                 for (const auto &reaction : mapEntry.second) {
                     if (reaction->getName() == name) return reaction.get();
                 }
@@ -449,25 +370,14 @@ namespace readdy {
             return pimpl->diffFun;
         }
 
-        const boost::uuids::uuid &KernelContext::registerDeathReaction(const std::string &name,
-                                                                       const std::string &particleType,
-                                                                       const double &rate) {
-            const auto &typeId = pimpl->typeMapping[particleType];
-            if (pimpl->internalReactionOneEductRegistry.find(typeId) == pimpl->internalReactionOneEductRegistry.end()) {
-                pimpl->internalReactionOneEductRegistry.emplace(typeId,
-                                                                std::vector<std::unique_ptr<reactions::Reaction<1>>>());
-            }
-            pimpl->internalReactionOneEductRegistry[typeId].push_back(
-                    pimpl->reactionFactory->createReaction<readdy::model::reactions::Death>(name, typeId, rate)
-            );
-            return pimpl->internalReactionOneEductRegistry[typeId].back()->getId();
-        }
-
         void KernelContext::configure() {
             pimpl->potentialO1Registry.clear();
             pimpl->potentialO2Registry.clear();
-            pimpl->reactionOneEductRegistry.clear();
-            pimpl->reactionTwoEductsRegistry.clear();
+            reactionOneEductRegistry->clear();
+            reactionTwoEductsRegistry->clear();
+            for(auto typeIt : pimpl->typeMapping) {
+
+            }
             for (auto &&e : pimpl->internalPotentialO1Registry) {
                 pimpl->potentialO1Registry[e.first] = std::vector<readdy::model::potentials::PotentialOrder1 *>();
                 pimpl->potentialO1Registry[e.first].reserve(e.second.size());
@@ -484,21 +394,21 @@ namespace readdy {
                     pimpl->potentialO2Registry[e.first].push_back(pot.get());
                 }
             }
-            for (auto &&e : pimpl->internalReactionOneEductRegistry) {
-                pimpl->reactionOneEductRegistry[e.first] = std::vector<reactions::Reaction<1> *>();
-                pimpl->reactionOneEductRegistry[e.first].reserve(e.second.size());
+            for (auto &&e : *internalReactionOneEductRegistry) {
+                (*reactionOneEductRegistry)[e.first] = std::vector<reactions::Reaction<1> *>();
+                (*reactionOneEductRegistry)[e.first].reserve(e.second.size());
                 std::for_each(e.second.begin(), e.second.end(),
                               [this, &e](const std::unique_ptr<reactions::Reaction<1>> &ptr) {
-                                  pimpl->reactionOneEductRegistry[e.first].push_back(ptr.get());
+                                  (*reactionOneEductRegistry)[e.first].push_back(ptr.get());
                               }
                 );
             }
-            for (auto &&e : pimpl->internalReactionTwoEductsRegistry) {
-                pimpl->reactionTwoEductsRegistry[e.first] = std::vector<reactions::Reaction<2> *>();
-                pimpl->reactionTwoEductsRegistry[e.first].reserve(e.second.size());
+            for (auto &&e : *internalReactionTwoEductsRegistry) {
+                (*reactionTwoEductsRegistry)[e.first] = std::vector<reactions::Reaction<2> *>();
+                (*reactionTwoEductsRegistry)[e.first].reserve(e.second.size());
                 std::for_each(e.second.begin(), e.second.end(),
                               [this, &e](const std::unique_ptr<reactions::Reaction<2>> &ptr) {
-                                  pimpl->reactionTwoEductsRegistry[e.first].push_back(ptr.get());
+                                  (*reactionTwoEductsRegistry)[e.first].push_back(ptr.get());
                               }
                 );
             }
@@ -527,6 +437,10 @@ namespace readdy {
         const std::unordered_map<readdy::util::ParticleTypePair, std::vector<potentials::PotentialOrder2 *>, readdy::util::ParticleTypePairHasher>
         KernelContext::getAllOrder2Potentials() const {
             return pimpl->potentialO2Registry;
+        }
+
+        const KernelContext::rdy_type_mapping &KernelContext::getTypeMapping() const {
+            return pimpl->typeMapping;
         }
 
         KernelContext &KernelContext::operator=(KernelContext &&rhs) = default;

--- a/readdy/main/model/Potentials.cpp
+++ b/readdy/main/model/Potentials.cpp
@@ -27,7 +27,7 @@ namespace readdy {
 
             CubePotential::CubePotential(const Kernel *const kernel) : PotentialOrder1(getPotentialName<CubePotential>()), kernel(kernel) { }
 
-            void CubePotential::configureForType(const unsigned int &type) {
+            void CubePotential::configureForType(const unsigned int type) {
                 particleRadius = kernel->getKernelContext().getParticleRadius(type);
                 for (auto i = 0; i < 3; i++) {
                     if (extent[i] > 0) {

--- a/readdy/main/model/RandomProvider.cpp
+++ b/readdy/main/model/RandomProvider.cpp
@@ -21,7 +21,7 @@ namespace readdy {
             std::unique_ptr<boost::random::uniform_01<>> uniform01 = std::make_unique<boost::random::uniform_01<>>();
         };
 
-        double RandomProvider::getNormal(const double &mean, const double &variance) {
+        double RandomProvider::getNormal(const double mean, const double variance) {
             if(mean == 0 && variance == 1) return (*pimpl->normal01)(*pimpl->gen);
             boost::random::normal_distribution<> n(mean, variance);
             return n(*pimpl->gen);
@@ -30,7 +30,7 @@ namespace readdy {
         RandomProvider::RandomProvider() : pimpl(std::make_unique<Impl>()) {
         }
 
-        Vec3 RandomProvider::getNormal3(const double &mean, const double &variance) {
+        Vec3 RandomProvider::getNormal3(const double mean, const double variance) {
             return {getNormal(mean, variance), getNormal(mean, variance), getNormal(mean, variance)};
         }
 

--- a/readdy/main/model/Vec3.cpp
+++ b/readdy/main/model/Vec3.cpp
@@ -86,7 +86,7 @@ namespace readdy {
             return {lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2]};
         }
 
-        Vec3 operator/(const Vec3 &lhs, const double &rhs) {
+        Vec3 operator/(const Vec3 &lhs, const double rhs) {
             return {lhs[0] / rhs, lhs[1] / rhs, lhs[2] / rhs};
         }
 

--- a/readdy/test/TestKernelContext.cpp
+++ b/readdy/test/TestKernelContext.cpp
@@ -49,13 +49,13 @@ namespace {
     };
 
     TEST_F(TestKernelContext, SetGetKBT) {
-        m::KernelContext ctx {reactionFactory.get()};
+        m::KernelContext ctx;
         ctx.setKBT(42);
         EXPECT_EQ(42, ctx.getKBT());
     }
 
     TEST_F(TestKernelContext, PeriodicBoundary) {
-        m::KernelContext ctx {reactionFactory.get()};
+        m::KernelContext ctx;
         ctx.setPeriodicBoundary(true, false, true);
         auto boundary = ctx.getPeriodicBoundary();
         EXPECT_TRUE(boundary[0]);
@@ -64,7 +64,7 @@ namespace {
     }
 
     TEST_F(TestKernelContext, BoxSize) {
-        m::KernelContext ctx {reactionFactory.get()};
+        m::KernelContext ctx;
         ctx.setBoxSize(10, 11, 12);
         auto box_size = ctx.getBoxSize();
         EXPECT_EQ(box_size[0], 10);
@@ -73,7 +73,7 @@ namespace {
     }
 
     TEST_F(TestKernelContext, PotentialOrder2Map) {
-        m::KernelContext ctx {reactionFactory.get()};
+        m::KernelContext ctx;
         auto p1 = std::make_unique<NOOPPotential>();
         ctx.registerOrder2Potential(p1.get(), "a", "b");
         ctx.registerOrder2Potential(p1.get(), "b", "a");

--- a/readdy/test/TestPerformance.cpp
+++ b/readdy/test/TestPerformance.cpp
@@ -51,8 +51,8 @@ namespace {
             }
         }
 
-        kernel.getKernelContext().registerFusionReaction("A+B->C", "A", "B", "C", .5, 2.0);
-        kernel.getKernelContext().registerFissionReaction("C->A+B", "C", "A", "B", .5, 2.0);
+        kernel.registerReaction<readdy::model::reactions::Fusion>("A+B->C", "A", "B", "C", .5, 2.0);
+        kernel.registerReaction<readdy::model::reactions::Fission>("C->A+B", "C", "A", "B", .5, 2.0);
 
         auto &&integrator = kernel.createProgram<readdy::model::programs::EulerBDIntegrator>();
         auto &&neighborList = kernel.createProgram<readdy::model::programs::UpdateNeighborList>();

--- a/readdy/test/TestPerformance.cpp
+++ b/readdy/test/TestPerformance.cpp
@@ -52,7 +52,7 @@ namespace {
         }
 
         kernel.getKernelContext().registerFusionReaction("A+B->C", "A", "B", "C", .5, 2.0);
-        kernel.getKernelContext().registerFissionReaction("C->A+B", "C", "A", "B", 2.0, .5);
+        kernel.getKernelContext().registerFissionReaction("C->A+B", "C", "A", "B", .5, 2.0);
 
         auto &&integrator = kernel.createProgram<readdy::model::programs::EulerBDIntegrator>();
         auto &&neighborList = kernel.createProgram<readdy::model::programs::UpdateNeighborList>();

--- a/readdy/test/TestReactions.cpp
+++ b/readdy/test/TestReactions.cpp
@@ -17,6 +17,12 @@ namespace {
         auto kernel = readdy::plugin::KernelProvider::getInstance().create("SingleCPU");
         kernel->getKernelContext().setDiffusionConstant("A", 1.0);
         kernel->getKernelContext().setDiffusionConstant("B", 2.0);
-        kernel->getKernelContext().registerConversionReaction("A to B", "A", "B", 0.55);
+        kernel->registerReaction<readdy::model::reactions::Conversion>("A to B", "A", "B", 0.55);
+
+        {
+            // sanity check of operator<< for reactions
+            const auto r = kernel->getReactionFactory().createReaction<readdy::model::reactions::Decay>("decay", 0, .1);
+            BOOST_LOG_TRIVIAL(debug) << "decay reaction: " << *r;
+        }
     }
 }

--- a/wrappers/python/src/cxx/api/PySimulation.cpp
+++ b/wrappers/python/src/cxx/api/PySimulation.cpp
@@ -145,7 +145,7 @@ BOOST_PYTHON_MODULE (api) {
             .def("register_reaction_enzymatic", &sim::registerEnzymaticReaction, bpy::return_internal_reference<>())
             .def("register_reaction_fission", &sim::registerFissionReaction, bpy::return_internal_reference<>())
             .def("register_reaction_fusion", &sim::registerFusionReaction, bpy::return_internal_reference<>())
-            .def("register_reaction_decay", &sim::registerDeathReaction, bpy::return_internal_reference<>())
+            .def("register_reaction_decay", &sim::registerDecayReaction, bpy::return_internal_reference<>())
             .def("get_recommended_time_step", &sim::getRecommendedTimeStep)
             .def("set_kernel", &sim::setKernel)
             .def("run", &sim::run);

--- a/wrappers/python/src/cxx/prototyping/ExportModel.cpp
+++ b/wrappers/python/src/cxx/prototyping/ExportModel.cpp
@@ -87,11 +87,11 @@ void exportModelClasses() {
             .def("get_dist_squared_fun", rpy::adapt_function(&getDistSquaredFunWrap))
             .def("get_particle_radius", +[](_rdy_ctx_t& self, std::string type) {return self.getParticleRadius(type);})
             .def("set_particle_radius", &_rdy_ctx_t::setParticleRadius)
-            .def("register_conversion_reaction", &_rdy_ctx_t::registerConversionReaction,  internal_ref<>())
-            .def("register_enzymatic_reaction", &_rdy_ctx_t::registerEnzymaticReaction,  internal_ref<>())
-            .def("register_fission_reaction", &_rdy_ctx_t::registerFissionReaction, internal_ref<>())
-            .def("register_fusion_reaction", &_rdy_ctx_t::registerFusionReaction, internal_ref<>())
-            .def("register_decay_reaction", &_rdy_ctx_t::registerDeathReaction, internal_ref<>())
+            .def("register_conversion_reaction", +[](_rdy_ctx_t &self, readdy::model::reactions::Conversion& r) -> const boost::uuids::uuid& {return self.registerReaction(&r);},  internal_ref<>())
+            .def("register_enzymatic_reaction", +[](_rdy_ctx_t &self, readdy::model::reactions::Enzymatic& r) -> const boost::uuids::uuid& {return self.registerReaction(&r);},  internal_ref<>())
+            .def("register_fission_reaction", +[](_rdy_ctx_t &self, readdy::model::reactions::Fission& r) -> const boost::uuids::uuid& {return self.registerReaction(&r);}, internal_ref<>())
+            .def("register_fusion_reaction", +[](_rdy_ctx_t &self, readdy::model::reactions::Fusion& r) -> const boost::uuids::uuid& {return self.registerReaction(&r);}, internal_ref<>())
+            .def("register_decay_reaction", +[](_rdy_ctx_t &self, readdy::model::reactions::Decay& r) -> const boost::uuids::uuid& {return self.registerReaction(&r);}, internal_ref<>())
             .def("register_potential_order_1",
                  +[](_rdy_ctx_t& self, _rdy_pot_1& pot, std::string type) -> const _rdy_uuid_t& {
                      return self.registerOrder1Potential(&pot, type);

--- a/wrappers/python/src/cxx/prototyping/ExportPotentials.cpp
+++ b/wrappers/python/src/cxx/prototyping/ExportPotentials.cpp
@@ -44,7 +44,7 @@ struct PyPotentialO1 : public _rdy_pot1, bpy::wrapper<_rdy_pot1> {
         energy += calculateEnergy(position);
     }
 
-    virtual void configureForType(const unsigned int &type) override {
+    virtual void configureForType(const unsigned int type) override {
         this->get_override("configure_for_type")(type);
     }
 

--- a/wrappers/python/src/python/readdy/examples/schnakenberg.py
+++ b/wrappers/python/src/python/readdy/examples/schnakenberg.py
@@ -96,9 +96,9 @@ class SchnakenbergSimulation(object):
         simulation.register_reaction_decay("2A -> 0", "2A", k3 * k3 * tau)
         simulation.register_reaction_fusion("A + A -> 2A", "A", "A", "2A", 1.0 / tau, reaction_radius, .5, .5)
         simulation.register_reaction_enzymatic("2A + B -> 2A + A", "2A", "B", "A", k_enzymatic, reaction_radius)
-        simulation.register_reaction_fission("GA -> GA + A", "GA", "GA", "A", reaction_radius, k2 * V / N_GA, .5, .5)
+        simulation.register_reaction_fission("GA -> GA + A", "GA", "GA", "A", k2 * V / N_GA, reaction_radius, .5, .5)
         simulation.register_reaction_decay("A -> 0", "A", k3)
-        simulation.register_reaction_fission("GB -> GB + B", "GB", "GB", "B", reaction_radius, k4 * V / N_GB, .5, .5)
+        simulation.register_reaction_fission("GB -> GB + B", "GB", "GB", "B", k4 * V / N_GB, reaction_radius, .5, .5)
 
         simulation.add_particle("A", Vec(0, 0, 0))
 

--- a/wrappers/python/src/python/readdy/examples/two_particles_mini_example.py
+++ b/wrappers/python/src/python/readdy/examples/two_particles_mini_example.py
@@ -64,7 +64,7 @@ class TwoParticlesMiniExample(object):
         self.simulation.register_potential_piecewise_weak_interaction("A", "B", force_constant, desired_dist, depth,
                                                                           no_interaction_dist)  # (force constant, desired dist, depth, no interaction dist)
         self.simulation.register_reaction_fusion("fusion", "A", "B", "C", 100., .3, .5, .5)
-        self.simulation.register_reaction_fission("fission", "C", "A", "B", .25, 100., .5, .5)
+        self.simulation.register_reaction_fission("fission", "C", "A", "B", 100., .25, .5, .5)
         self.simulation.register_potential_box("A", 100., Vec(-.75, -.75, -.75), Vec(1.5, 1.5, 1.5), False)
         self.simulation.register_potential_box("B", 100., Vec(-.75, -.75, -.75), Vec(1.5, 1.5, 1.5), False)
         self.simulation.register_potential_box("C", 100., Vec(-.75, -.75, -.75), Vec(1.5, 1.5, 1.5), False)


### PR DESCRIPTION
The KernelContext does not depend on the ReactionFactory anymore and the Kernel itself dispatches the reactions into the context.
Further, the argument sequence for reactions has been unified: First the name, then educts, then products, then the educt distance, then the product distance and then weights (some of them omitted depending on which reaction type is considered).
Also, with respect to issue #17, added an action parameter (create=default/clear) to the UpdateNeighborList program such that the neighbor list is cleared after a simulation run().