### PR TITLE
Minor

### DIFF
--- a/include/readdy/api/Simulation.h
+++ b/include/readdy/api/Simulation.h
@@ -134,6 +134,12 @@ public:
     void setPeriodicBoundary(std::array<bool, 3> periodic);
 
     /**
+     * Allows to set an expected maximal number of particles in order to avoid reallocations.
+     * @param n expected number of particles
+     */
+    void setExpectedMaxNParticles(const std::size_t n);
+
+    /**
      * Registers a predefined observable with the kernel. A list of available observables can be obtained by
      * getAvailableObservables().
      * @param stride the stride argument which decides how often the observable gets called

--- a/include/readdy/api/Simulation.h
+++ b/include/readdy/api/Simulation.h
@@ -86,19 +86,6 @@ public:
      */
     readdy::model::Vec3 getBoxSize() const;
 
-    /**
-     * If this method is called, a trajectory file will be created and the simulation trajectory will be recorded
-     * into that file. The simulation trajectory consists out of every "stride"-th frame and will be flushed every
-     * "stride * flushStride"-th frame.
-     *
-     * @param fileName The file name
-     * @param stride the stride at which to record the trajectory
-     * @param flushStride parameter determining how often the trajectory will be written to disk
-     */
-    void recordTrajectory(const std::string &fileName, const unsigned int stride, const unsigned int flushStride);
-
-    void closeTrajectoryFile();
-
     readdy::model::TopologyParticle
     createTopologyParticle(const std::string &type, const readdy::model::Vec3 &pos) const;
 

--- a/include/readdy/api/SimulationScheme.h
+++ b/include/readdy/api/SimulationScheme.h
@@ -179,6 +179,11 @@ public:
         return *this;
     }
 
+    SchemeConfigurator &withSkinSize(double skin = -1) {
+        skinSize = skin;
+        return *this;
+    }
+
     virtual std::unique_ptr<SchemeType> configure(double timeStep) {
         using default_integrator_t = readdy::model::actions::EulerBDIntegrator;
         using default_reactions_t = readdy::model::actions::reactions::Gillespie;
@@ -200,7 +205,7 @@ public:
         }
         if (scheme->forces || scheme->reactionScheduler) {
             scheme->neighborList = scheme->kernel
-                    ->template createAction<update_neighbor_list_t>(update_neighbor_list_t::Operation::create, -1);
+                    ->template createAction<update_neighbor_list_t>(update_neighbor_list_t::Operation::create, skinSize);
             scheme->clearNeighborList = scheme->kernel
                     ->template createAction<update_neighbor_list_t>(update_neighbor_list_t::Operation::clear, -1);
         }
@@ -220,6 +225,7 @@ protected:
     bool evaluateObservablesSet = false;
     bool includeForcesSet = false;
     std::unique_ptr<SchemeType> scheme = nullptr;
+    double skinSize = -1;
 };
 
 class AdvancedScheme : public SimulationScheme {
@@ -327,6 +333,11 @@ public:
         return *this;
     }
 
+    SchemeConfigurator &withSkinSize(double skin = -1) {
+        skinSize = skin;
+        return *this;
+    }
+
     std::unique_ptr<AdvancedScheme> configure(double timeStep) {
         using default_integrator_t = readdy::model::actions::EulerBDIntegrator;
         using default_reactions_t = readdy::model::actions::reactions::Gillespie;
@@ -351,7 +362,7 @@ public:
         }
         if (scheme->forces || scheme->reactionScheduler) {
             scheme->neighborList = scheme->kernel
-                    ->template createAction<update_neighbor_list_t>(update_neighbor_list_t::Operation::create, -1);
+                    ->template createAction<update_neighbor_list_t>(update_neighbor_list_t::Operation::create, skinSize);
             scheme->clearNeighborList = scheme->kernel
                     ->template createAction<update_neighbor_list_t>(update_neighbor_list_t::Operation::clear, -1);
         }
@@ -372,6 +383,7 @@ protected:
     bool evaluateObservablesSet = false;
     bool includeForcesSet = false;
     bool includeCompartmentsSet = false;
+    double skinSize = -1;
 
 };
 

--- a/include/readdy/api/SimulationScheme.h
+++ b/include/readdy/api/SimulationScheme.h
@@ -274,8 +274,7 @@ public:
     SchemeConfigurator(model::Kernel *const kernel, bool useDefaults = true) : scheme(std::make_unique<AdvancedScheme>(kernel)),
                                                                                useDefaults(useDefaults) {}
 
-    // fixme @chrisfroe: shouldn't this be include = true?
-    SchemeConfigurator &includeCompartments(bool include = false) {
+    SchemeConfigurator &includeCompartments(bool include = true) {
         if (include) {
             scheme->compartments = scheme->kernel->template createAction<readdy::model::actions::EvaluateCompartments>();
         } else {

--- a/include/readdy/api/SimulationScheme.h
+++ b/include/readdy/api/SimulationScheme.h
@@ -268,6 +268,7 @@ public:
     SchemeConfigurator(model::Kernel *const kernel, bool useDefaults = true) : scheme(std::make_unique<AdvancedScheme>(kernel)),
                                                                                useDefaults(useDefaults) {}
 
+    // fixme @chrisfroe: shouldn't this be include = true?
     SchemeConfigurator &includeCompartments(bool include = false) {
         if (include) {
             scheme->compartments = scheme->kernel->template createAction<readdy::model::actions::EvaluateCompartments>();

--- a/include/readdy/api/bits/Simulation_misc.h
+++ b/include/readdy/api/bits/Simulation_misc.h
@@ -38,11 +38,9 @@
 NAMESPACE_BEGIN(readdy)
 
 struct Simulation::Impl {
-    std::unordered_map<unsigned long, readdy::signals::scoped_connection> observableConnections{};
-    std::unordered_map<unsigned long, std::unique_ptr<readdy::model::observables::ObservableBase>> observables{};
     plugin::KernelProvider::kernel_ptr kernel;
-    std::unique_ptr<io::File> trajectoryFile;
-    unsigned long trajectoryFileId;
+    std::unordered_map<unsigned long, std::unique_ptr<readdy::model::observables::ObservableBase>> observables{};
+    std::unordered_map<unsigned long, readdy::signals::scoped_connection> observableConnections{};
     unsigned long counter = 0;
 };
 

--- a/include/readdy/common/thread/scoped_async.h
+++ b/include/readdy/common/thread/scoped_async.h
@@ -1,0 +1,65 @@
+/********************************************************************
+ * Copyright © 2016 Computational Molecular Biology Group,          * 
+ *                  Freie Universität Berlin (GER)                  *
+ *                                                                  *
+ * This file is part of ReaDDy.                                     *
+ *                                                                  *
+ * ReaDDy is free software: you can redistribute it and/or modify   *
+ * it under the terms of the GNU Lesser General Public License as   *
+ * published by the Free Software Foundation, either version 3 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU Lesser General Public License for more details.              *
+ *                                                                  *
+ * You should have received a copy of the GNU Lesser General        *
+ * Public License along with this program. If not, see              *
+ * <http://www.gnu.org/licenses/>.                                  *
+ ********************************************************************/
+
+
+/**
+ * << detailed description >>
+ *
+ * @file scoped_async.h
+ * @brief << brief description >>
+ * @author clonker
+ * @date 28.03.17
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#include <future>
+#include <readdy/common/macros.h>
+#include <readdy/common/logging.h>
+
+NAMESPACE_BEGIN(readdy)
+NAMESPACE_BEGIN(util)
+NAMESPACE_BEGIN(thread)
+
+class scoped_async {
+    std::future<void> async_;
+public:
+    template<typename Function, typename... Args>
+    explicit scoped_async(Function &&fun, Args &&... args)
+            : async_(std::async(std::launch::async, std::forward<Function>(fun), std::forward<Args>(args)...)) {}
+
+    ~scoped_async() {
+        if(async_.valid()) async_.wait();
+    }
+
+    scoped_async(const scoped_async &) = delete;
+
+    scoped_async &operator=(const scoped_async &) = delete;
+
+    scoped_async(scoped_async &&) = default;
+
+    scoped_async &operator=(scoped_async &&) = default;
+};
+
+NAMESPACE_END(thread)
+NAMESPACE_END(util)
+NAMESPACE_END(readdy)

--- a/include/readdy/common/thread/scoped_thread.h
+++ b/include/readdy/common/thread/scoped_thread.h
@@ -46,7 +46,9 @@ public:
      * Creates a new scoped_thread based on a thread object
      * @param _t the reference thread
      */
-    explicit scoped_thread(std::thread _t) : t(std::move(_t)) {
+    template<typename Function, typename... Args>
+    explicit scoped_thread(Function &&fun, Args &&... args)
+            : t(std::forward<Function>(fun), std::forward<Args>(args)...) {
         if (!t.joinable()) throw std::logic_error("No thread!");
     }
 

--- a/include/readdy/kernel/singlecpu/SCPUStateModel.h
+++ b/include/readdy/kernel/singlecpu/SCPUStateModel.h
@@ -94,6 +94,8 @@ public:
 
     const std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>& reactionCounts() const;
 
+    virtual void expected_n_particles(const std::size_t n) override;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> pimpl;

--- a/include/readdy/kernel/singlecpu/model/SCPUParticleData.h
+++ b/include/readdy/kernel/singlecpu/model/SCPUParticleData.h
@@ -129,6 +129,8 @@ public:
 
     index_t n_deactivated() const;
 
+    void reserve(std::size_t n);
+
     void clear();
 
     const Entry &entry_at(index_t) const;

--- a/include/readdy/model/Kernel.h
+++ b/include/readdy/model/Kernel.h
@@ -227,6 +227,8 @@ public:
     const readdy::model::top::TopologyActionFactory *const getTopologyActionFactory() const;
     readdy::model::top::TopologyActionFactory *const getTopologyActionFactory();
 
+    void expected_n_particles(const std::size_t n);
+
 protected:
 
     unsigned int getTypeIdRequireNormalFlavor(const std::string &) const;

--- a/include/readdy/model/KernelStateModel.h
+++ b/include/readdy/model/KernelStateModel.h
@@ -67,6 +67,8 @@ public:
     virtual void removeAllParticles() = 0;
 
     virtual double getEnergy() const = 0;
+
+    virtual void expected_n_particles(const std::size_t n) = 0;
 };
 
 NAMESPACE_END(model)

--- a/include/readdy/model/observables/Observable.h
+++ b/include/readdy/model/observables/Observable.h
@@ -102,7 +102,9 @@ public:
     /**
      * The destructor.
      */
-    virtual ~ObservableBase() = default;
+    virtual ~ObservableBase() {
+        log::trace("destroying observable base");
+    };
 
     /**
      * Method that will trigger a callback with the current results if shouldExecuteCallback() is true.

--- a/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
@@ -79,6 +79,8 @@ public:
 
     model::CPUNeighborList *const getNeighborList();
 
+    virtual void expected_n_particles(const std::size_t n) override;
+
     virtual void clearNeighborList() override;
 
     virtual readdy::model::top::GraphTopology *const

--- a/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
@@ -38,6 +38,7 @@
 #include <readdy/common/thread/Config.h>
 #include <readdy/kernel/cpu/model/CPUParticleData.h>
 #include <readdy/model/reactions/ReactionRecord.h>
+#include <readdy/common/thread/scoped_async.h>
 
 namespace readdy {
 namespace kernel {

--- a/kernels/cpu/include/readdy/kernel/cpu/model/CPUParticleData.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/model/CPUParticleData.h
@@ -112,6 +112,8 @@ public:
 
     std::size_t size() const;
 
+    void reserve(std::size_t n);
+
     bool empty() const;
 
     void clear();

--- a/kernels/cpu/include/readdy/kernel/cpu/util/config.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/util/config.h
@@ -1,0 +1,45 @@
+/********************************************************************
+ * Copyright © 2016 Computational Molecular Biology Group,          * 
+ *                  Freie Universität Berlin (GER)                  *
+ *                                                                  *
+ * This file is part of ReaDDy.                                     *
+ *                                                                  *
+ * ReaDDy is free software: you can redistribute it and/or modify   *
+ * it under the terms of the GNU Lesser General Public License as   *
+ * published by the Free Software Foundation, either version 3 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU Lesser General Public License for more details.              *
+ *                                                                  *
+ * You should have received a copy of the GNU Lesser General        *
+ * Public License along with this program. If not, see              *
+ * <http://www.gnu.org/licenses/>.                                  *
+ ********************************************************************/
+
+
+/**
+ * << detailed description >>
+ *
+ * @file config.h
+ * @brief << brief description >>
+ * @author clonker
+ * @date 28.03.17
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#include <readdy/common/thread/scoped_async.h>
+#include <readdy/common/thread/scoped_thread.h>
+
+namespace readdy {
+namespace kernel {
+namespace cpu {
+//using threading_model = readdy::util::thread::scoped_thread;
+using threading_model = readdy::util::thread::scoped_async;
+}
+}
+}

--- a/kernels/cpu/src/CPUStateModel.cpp
+++ b/kernels/cpu/src/CPUStateModel.cpp
@@ -33,6 +33,7 @@
 #include <readdy/kernel/cpu/CPUStateModel.h>
 #include <readdy/common/thread/barrier.h>
 #include <readdy/common/thread/scoped_async.h>
+#include <readdy/kernel/cpu/util/config.h>
 
 namespace readdy {
 namespace kernel {
@@ -160,7 +161,7 @@ void CPUStateModel::calculateForces() {
         std::vector<std::future<double>> energyFutures;
         energyFutures.reserve(config->nThreads());
         {
-            std::vector<thd::scoped_async> threads;
+            std::vector<threading_model> threads;
             threads.reserve(config->nThreads());
             const std::size_t grainSize = (pimpl->cdata().size()) / config->nThreads();
             const std::size_t grainSizeTopologies = pimpl->topologies.size() / config->nThreads();

--- a/kernels/cpu/src/CPUStateModel.cpp
+++ b/kernels/cpu/src/CPUStateModel.cpp
@@ -326,6 +326,13 @@ readdy::model::Particle CPUStateModel::getParticleForIndex(const std::size_t ind
     return pimpl->cdata<false>().getParticle(index);
 }
 
+void CPUStateModel::expected_n_particles(const std::size_t n) {
+    auto& data = pimpl->data<false>();
+    if(data.size() < n) {
+        data.reserve(n);
+    }
+}
+
 CPUStateModel::~CPUStateModel() = default;
 
 

--- a/kernels/cpu/src/actions/CPUEulerBDIntegrator.cpp
+++ b/kernels/cpu/src/actions/CPUEulerBDIntegrator.cpp
@@ -31,6 +31,7 @@
 
 #include <readdy/common/thread/scoped_async.h>
 #include <readdy/kernel/cpu/actions/CPUEulerBDIntegrator.h>
+#include <readdy/kernel/cpu/util/config.h>
 
 namespace readdy {
 namespace kernel {
@@ -43,7 +44,7 @@ namespace thd = readdy::util::thread;
 void CPUEulerBDIntegrator::perform() {
     auto& pd = *kernel->getCPUKernelStateModel().getParticleData();
     const auto size = pd.size();
-    std::vector<thd::scoped_async> threads;
+    std::vector<threading_model> threads;
     threads.reserve(kernel->getNThreads());
     const std::size_t grainSize = size / kernel->getNThreads();
 

--- a/kernels/cpu/src/actions/CPUEulerBDIntegrator.cpp
+++ b/kernels/cpu/src/actions/CPUEulerBDIntegrator.cpp
@@ -29,7 +29,7 @@
  * @date 07.07.16
  */
 
-#include <readdy/common/thread/scoped_thread.h>
+#include <readdy/common/thread/scoped_async.h>
 #include <readdy/kernel/cpu/actions/CPUEulerBDIntegrator.h>
 
 namespace readdy {
@@ -43,7 +43,7 @@ namespace thd = readdy::util::thread;
 void CPUEulerBDIntegrator::perform() {
     auto& pd = *kernel->getCPUKernelStateModel().getParticleData();
     const auto size = pd.size();
-    std::vector<thd::scoped_thread> threads;
+    std::vector<thd::scoped_async> threads;
     threads.reserve(kernel->getNThreads());
     const std::size_t grainSize = size / kernel->getNThreads();
 
@@ -68,10 +68,10 @@ void CPUEulerBDIntegrator::perform() {
     auto work_iter = pd.begin();
     {
         for (unsigned int i = 0; i < kernel->getNThreads() - 1; ++i) {
-            threads.push_back(thd::scoped_thread(std::thread(worker, work_iter, work_iter + grainSize)));
+            threads.emplace_back(worker, work_iter, work_iter + grainSize);
             work_iter += grainSize;
         }
-        threads.push_back(thd::scoped_thread(std::thread(worker, work_iter, pd.end())));
+        threads.emplace_back(worker, work_iter, pd.end());
     }
 
 }

--- a/kernels/cpu/src/actions/reactions/CPUGillespieParallel.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUGillespieParallel.cpp
@@ -32,8 +32,8 @@
 #include <future>
 #include <queue>
 
+#include <readdy/common/thread/scoped_async.h>
 #include <readdy/kernel/cpu/actions/reactions/CPUGillespieParallel.h>
-#include <readdy/common/thread/scoped_thread.h>
 
 
 using rdy_particle_t = readdy::model::Particle;
@@ -60,8 +60,8 @@ long CPUGillespieParallel::SlicedBox::getShellIndex(const vec_t &pos) const {
 }
 
 CPUGillespieParallel::SlicedBox::SlicedBox(unsigned int id, vec_t lowerLeftVertex, vec_t upperRightVertex,
-                                        double maxReactionRadius,
-                                        unsigned int longestAxis)
+                                           double maxReactionRadius,
+                                           unsigned int longestAxis)
         : id(id), lowerLeftVertex(lowerLeftVertex), upperRightVertex(upperRightVertex), longestAxis(longestAxis) {
     leftBoundary = lowerLeftVertex[longestAxis];
     rightBoundary = upperRightVertex[longestAxis];
@@ -78,10 +78,10 @@ bool CPUGillespieParallel::SlicedBox::isInBox(const vec_t &particle) const {
 }
 
 void CPUGillespieParallel::perform() {
-    if(kernel->getKernelContext().recordReactionCounts()) {
-        auto& order1 = std::get<0>(kernel->getCPUKernelStateModel().reactionCounts());
-        auto& order2 = std::get<1>(kernel->getCPUKernelStateModel().reactionCounts());
-        if(order1.empty() && order2.empty()) {
+    if (kernel->getKernelContext().recordReactionCounts()) {
+        auto &order1 = std::get<0>(kernel->getCPUKernelStateModel().reactionCounts());
+        auto &order2 = std::get<1>(kernel->getCPUKernelStateModel().reactionCounts());
+        if (order1.empty() && order2.empty()) {
             const auto n_reactions_order1 = kernel->getKernelContext().getAllOrder1Reactions().size();
             const auto n_reactions_order2 = kernel->getKernelContext().getAllOrder2Reactions().size();
             order1.resize(n_reactions_order1);
@@ -196,7 +196,7 @@ void CPUGillespieParallel::handleBoxReactions() {
     using promise_records = std::promise<std::vector<record_t>>;
     using promise_counts = std::promise<reaction_counts_t>;
 
-    auto worker = [this](SlicedBox &box, ctx_t ctx, data_t *data, nl_t * nl, promise_t update,
+    auto worker = [this](SlicedBox &box, ctx_t ctx, data_t *data, nl_t *nl, promise_t update,
                          promise_new_particles_t newParticles, promise_records promiseRecords, promise_counts counts) {
         const auto &fixPos = kernel->getKernelContext().getFixPositionFun();
         const auto &d2 = kernel->getKernelContext().getDistSquaredFun();
@@ -221,23 +221,25 @@ void CPUGillespieParallel::handleBoxReactions() {
             gatherEvents(kernel, box.particleIndices, nl, *data, localAlpha, localEvents, d2);
             // handle events
             {
-                reaction_counts_t local_counts {};
-                reaction_counts_t* local_counts_ptr = nullptr;
-                if(ctx.recordReactionCounts()) {
+                reaction_counts_t local_counts{};
+                reaction_counts_t *local_counts_ptr = nullptr;
+                if (ctx.recordReactionCounts()) {
                     const auto n_reactions_order1 = kernel->getKernelContext().getAllOrder1Reactions().size();
                     const auto n_reactions_order2 = kernel->getKernelContext().getAllOrder2Reactions().size();
                     std::get<0>(local_counts).resize(n_reactions_order1);
                     std::get<1>(local_counts).resize(n_reactions_order2);
                     local_counts_ptr = &local_counts;
                 }
-                if(ctx.recordReactionsWithPositions()) {
+                if (ctx.recordReactionsWithPositions()) {
                     std::vector<record_t> records;
-                    auto result = handleEventsGillespie(kernel, timeStep, false, approximateRate, std::move(localEvents),
+                    auto result = handleEventsGillespie(kernel, timeStep, false, approximateRate,
+                                                        std::move(localEvents),
                                                         &records, local_counts_ptr);
                     newParticles.set_value(std::move(result));
                     promiseRecords.set_value(std::move(records));
                 } else {
-                    auto result = handleEventsGillespie(kernel, timeStep, false, approximateRate, std::move(localEvents),
+                    auto result = handleEventsGillespie(kernel, timeStep, false, approximateRate,
+                                                        std::move(localEvents),
                                                         nullptr, local_counts_ptr);
                     newParticles.set_value(std::move(result));
                     std::vector<record_t> no_records;
@@ -257,7 +259,7 @@ void CPUGillespieParallel::handleBoxReactions() {
     auto &stateModel = kernel->getCPUKernelStateModel();
     {
         //readdy::util::Timer t ("\t run threads");
-        std::vector<thd::scoped_thread> threads;
+        std::vector<thd::scoped_async> threads;
         for (unsigned int i = 0; i < kernel->getNThreads(); ++i) {
             // nboxes == nthreads
             promise_t promise;
@@ -268,39 +270,31 @@ void CPUGillespieParallel::handleBoxReactions() {
             records.push_back(promiseRecords.get_future());
             promise_counts promiseCounts;
             counts.push_back(promiseCounts.get_future());
-            threads.push_back(
-                    thd::scoped_thread(std::thread(
-                            worker, std::ref(boxes[i]),
-                            std::ref(kernel->getKernelContext()),
-                            stateModel.getParticleData(),
-                            stateModel.getNeighborList(),
-                            std::move(promise),
-                            std::move(promiseParticles),
-                            std::move(promiseRecords),
-                            std::move(promiseCounts)
-                    ))
-            );
+            threads.emplace_back(worker, std::ref(boxes[i]), std::ref(kernel->getKernelContext()),
+                                 stateModel.getParticleData(), stateModel.getNeighborList(), std::move(promise),
+                                 std::move(promiseParticles), std::move(promiseRecords), std::move(promiseCounts));
         }
     }
     std::vector<std::vector<record_t>> attainedRecords;
-    attainedRecords.reserve(records.size()+1);
+    attainedRecords.reserve(records.size() + 1);
     {
         //readdy::util::Timer t ("\t fix marked");
         auto &data = *stateModel.getParticleData();
-        const auto& d2 = kernel->getKernelContext().getDistSquaredFun();
+        const auto &d2 = kernel->getKernelContext().getDistSquaredFun();
         auto neighbor_list = stateModel.getNeighborList();
         std::vector<event_t> evilEvents{};
         double alpha = 0;
         long n_local_problematic = 0;
-        for (auto&& update : updates) {
+        for (auto &&update : updates) {
             auto local_problematic = std::move(update.get());
             n_local_problematic += local_problematic.size();
             gatherEvents(kernel, std::move(local_problematic), neighbor_list, data, alpha, evilEvents, d2);
         }
         auto count_ptr = kernel->getKernelContext().recordReactionCounts() ? &stateModel.reactionCounts() : nullptr;
-        if(kernel->getKernelContext().recordReactionsWithPositions()) {
+        if (kernel->getKernelContext().recordReactionsWithPositions()) {
             std::vector<record_t> newRecords;
-            auto newProblemParticles = handleEventsGillespie(kernel, timeStep, false, approximateRate, std::move(evilEvents), &newRecords, count_ptr);
+            auto newProblemParticles = handleEventsGillespie(kernel, timeStep, false, approximateRate,
+                                                             std::move(evilEvents), &newRecords, count_ptr);
             const auto &fixPos = kernel->getKernelContext().getFixPositionFun();
             for (auto &&future : newParticles) {
                 neighbor_list->updateData(std::move(future.get()));
@@ -308,18 +302,19 @@ void CPUGillespieParallel::handleBoxReactions() {
             neighbor_list->updateData(std::move(newProblemParticles));
             std::size_t totalRecordSize = newRecords.size();
             attainedRecords.push_back(std::move(newRecords));
-            for(auto &&future : records) {
+            for (auto &&future : records) {
                 attainedRecords.push_back(std::move(future.get()));
                 totalRecordSize += attainedRecords.back().size();
             }
-            auto& modelRecords = kernel->getCPUKernelStateModel().reactionRecords();
+            auto &modelRecords = kernel->getCPUKernelStateModel().reactionRecords();
             modelRecords.clear();
             modelRecords.reserve(totalRecordSize);
-            for(const auto& r : attainedRecords) {
+            for (const auto &r : attainedRecords) {
                 modelRecords.insert(modelRecords.end(), r.begin(), r.end());
             }
         } else {
-            auto newProblemParticles = handleEventsGillespie(kernel, timeStep, false, approximateRate, std::move(evilEvents), nullptr, count_ptr);
+            auto newProblemParticles = handleEventsGillespie(kernel, timeStep, false, approximateRate,
+                                                             std::move(evilEvents), nullptr, count_ptr);
             const auto &fixPos = kernel->getKernelContext().getFixPositionFun();
             for (auto &&future : newParticles) {
                 neighbor_list->updateData(std::move(future.get()));
@@ -328,9 +323,9 @@ void CPUGillespieParallel::handleBoxReactions() {
         }
         {
             // update counts
-            auto& modelCounts = stateModel.reactionCounts();
-            auto& o1 = std::get<0>(modelCounts);
-            auto& o2 = std::get<1>(modelCounts);
+            auto &modelCounts = stateModel.reactionCounts();
+            auto &o1 = std::get<0>(modelCounts);
+            auto &o2 = std::get<1>(modelCounts);
             for (auto &&future : counts) {
                 auto c = std::move(future.get());
                 std::transform(o1.begin(), o1.end(), std::get<0>(c).begin(), o1.begin(), std::plus<std::size_t>());
@@ -344,14 +339,14 @@ void CPUGillespieParallel::handleBoxReactions() {
 
 void CPUGillespieParallel::findProblematicParticles(
         data_t::index_t index, const SlicedBox &box, ctx_t ctx,
-        const data_t &data, nl_t* nl, std::set<data_t::index_t> &problematic,
-        const readdy::model::KernelContext::dist_squared_fun& d2
+        const data_t &data, nl_t *nl, std::set<data_t::index_t> &problematic,
+        const readdy::model::KernelContext::dist_squared_fun &d2
 ) const {
     if (problematic.find(index) != problematic.end()) {
         return;
     }
 
-    const auto& me = data.entry_at(index);
+    const auto &me = data.entry_at(index);
 
     // we only want out most particles here, since the transitively dependent particles
     // are resolved within this method and therefore have no significance as input parameter
@@ -363,7 +358,7 @@ void CPUGillespieParallel::findProblematicParticles(
     std::queue<decltype(index)> bfs{};
 
     for (const auto neighbor : nl->find_neighbors(index)) {
-        const auto& neighborEntry = data.entry_at(neighbor);
+        const auto &neighborEntry = data.entry_at(neighbor);
         const auto &reactions = ctx.getOrder2Reactions(me.type, neighborEntry.type);
         if (!reactions.empty()) {
             const auto distSquared = d2(neighborEntry.position(), me.position());
@@ -383,12 +378,12 @@ void CPUGillespieParallel::findProblematicParticles(
     //BOOST_LOG_TRIVIAL(debug) << "------------------ BFS -----------------";
     while (!bfs.empty()) {
         const auto x = bfs.front();
-        const auto& x_entry = data.entry_at(x);
+        const auto &x_entry = data.entry_at(x);
         bfs.pop();
         const auto x_shell_idx = box.getShellIndex(x_entry.position());
         //BOOST_LOG_TRIVIAL(debug) << " ----> looking at neighbors of " << x;
         for (const auto x_neighbor : nl->find_neighbors(x)) {
-            const auto& x_neighbor_entry = data.entry_at(x_neighbor);
+            const auto &x_neighbor_entry = data.entry_at(x_neighbor);
             //BOOST_LOG_TRIVIAL(debug) << "\t ----> neighbor " << x_neighbor;
             /*if(neighbor_shell_idx == 0) {
                 //BOOST_LOG_TRIVIAL(debug) << "\t ----> neighbor was in outer shell, ignore";

--- a/kernels/cpu/src/actions/reactions/CPUGillespieParallel.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUGillespieParallel.cpp
@@ -34,6 +34,7 @@
 
 #include <readdy/common/thread/scoped_async.h>
 #include <readdy/kernel/cpu/actions/reactions/CPUGillespieParallel.h>
+#include <readdy/kernel/cpu/util/config.h>
 
 
 using rdy_particle_t = readdy::model::Particle;
@@ -259,7 +260,7 @@ void CPUGillespieParallel::handleBoxReactions() {
     auto &stateModel = kernel->getCPUKernelStateModel();
     {
         //readdy::util::Timer t ("\t run threads");
-        std::vector<thd::scoped_async> threads;
+        std::vector<threading_model> threads;
         for (unsigned int i = 0; i < kernel->getNThreads(); ++i) {
             // nboxes == nthreads
             promise_t promise;

--- a/kernels/cpu/src/actions/reactions/CPUUncontrolledApproximation.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUUncontrolledApproximation.cpp
@@ -36,6 +36,7 @@
 #include <readdy/kernel/cpu/actions/reactions/CPUUncontrolledApproximation.h>
 #include <readdy/kernel/cpu/actions/reactions/Event.h>
 #include <readdy/kernel/cpu/actions/reactions/ReactionUtils.h>
+#include <readdy/kernel/cpu/util/config.h>
 
 namespace readdy {
 namespace kernel {
@@ -141,7 +142,7 @@ void CPUUncontrolledApproximation::perform() {
     {
         const std::size_t grainSize = data.size() / kernel->getNThreads();
 
-        std::vector<thd::scoped_async> threads;
+        std::vector<threading_model> threads;
 
         auto it = data.cbegin();
         auto it_nl = nl.cbegin();

--- a/kernels/cpu/src/model/CPUNeighborList.cpp
+++ b/kernels/cpu/src/model/CPUNeighborList.cpp
@@ -43,6 +43,7 @@
 #include <readdy/kernel/cpu/util/hilbert.h>
 #include <readdy/common/thread/notification_barrier.h>
 #include <readdy/common/Utils.h>
+#include <readdy/kernel/cpu/util/config.h>
 
 namespace readdy {
 namespace kernel {
@@ -300,7 +301,7 @@ void CPUNeighborList::fillCells() {
                         };
 
                         {
-                            std::vector<thd::scoped_async> threads;
+                            std::vector<threading_model> threads;
                             threads.reserve(config->nThreads());
                             auto data_it = data.begin();
                             auto hilberts_it = hilbert_indices.begin();
@@ -391,7 +392,7 @@ void CPUNeighborList::fillCells() {
                 }
             };
 
-            std::vector<thd::scoped_async> threads;
+            std::vector<threading_model> threads;
             threads.reserve(config->nThreads());
 
             auto it_cells = cells.begin();
@@ -473,7 +474,7 @@ void CPUNeighborList::fillCells() {
                 // readdy::util::Timer t("        update dirty cells");
                 thd::barrier b(config->nThreads());
 
-                std::vector<thd::scoped_async> threads;
+                std::vector<threading_model> threads;
                 threads.reserve(config->nThreads());
 
                 // log::warn("got dirty cells {} vs total cells {}", dirtyCells.size(), cells.size());
@@ -743,7 +744,7 @@ std::unordered_set<CPUNeighborList::Cell *> CPUNeighborList::findDirtyCells() {
     dirtyCells.reserve(config->nThreads());
     {
         auto it_cells = cells.begin();
-        std::vector<thd::scoped_async> threads;
+        std::vector<threading_model> threads;
         const std::size_t grainSize = cells.size() / config->nThreads();
         for (int i = 0; i < config->nThreads() - 1; ++i) {
             promise_t promise;

--- a/kernels/cpu/src/model/CPUParticleData.cpp
+++ b/kernels/cpu/src/model/CPUParticleData.cpp
@@ -295,6 +295,11 @@ CPUParticleData::addTopologyParticles(const std::vector<CPUParticleData::top_par
     return indices;
 }
 
+void CPUParticleData::reserve(std::size_t n) {
+    entries.reserve(n);
+    neighbors.reserve(n);
+}
+
 }
 }
 }

--- a/kernels/cpu/src/observables/CPUObservables.cpp
+++ b/kernels/cpu/src/observables/CPUObservables.cpp
@@ -31,7 +31,7 @@
 
 #include <future>
 
-#include <readdy/common/thread/scoped_thread.h>
+#include <readdy/common/thread/scoped_async.h>
 
 #include <readdy/kernel/cpu/observables/CPUObservables.h>
 #include <readdy/kernel/cpu/CPUKernel.h>
@@ -106,17 +106,17 @@ void CPUHistogramAlongAxis::evaluate() {
     {
         const std::size_t grainSize = data->size() / kernel->getNThreads();
 
-        std::vector<thd::scoped_thread> threads;
+        std::vector<thd::scoped_async> threads;
         Iter workIter = data->cbegin();
         for (unsigned int i = 0; i < kernel->getNThreads() - 1; ++i) {
             std::promise<result_t> promise;
             updates.push_back(promise.get_future());
-            threads.push_back(thd::scoped_thread(std::thread(worker, workIter, workIter + grainSize, std::move(promise))));
+            threads.emplace_back(worker, workIter, workIter + grainSize, std::move(promise));
             workIter += grainSize;
         }
         std::promise<result_t> promise;
         updates.push_back(promise.get_future());
-        threads.push_back(thd::scoped_thread(std::thread(worker, workIter, data->cend(), std::move(promise))));
+        threads.emplace_back(worker, workIter, data->cend(), std::move(promise));
     }
 
     for (auto &update : updates) {

--- a/kernels/cpu/src/observables/CPUObservables.cpp
+++ b/kernels/cpu/src/observables/CPUObservables.cpp
@@ -35,6 +35,7 @@
 
 #include <readdy/kernel/cpu/observables/CPUObservables.h>
 #include <readdy/kernel/cpu/CPUKernel.h>
+#include <readdy/kernel/cpu/util/config.h>
 
 namespace readdy {
 namespace kernel {
@@ -106,7 +107,7 @@ void CPUHistogramAlongAxis::evaluate() {
     {
         const std::size_t grainSize = data->size() / kernel->getNThreads();
 
-        std::vector<thd::scoped_async> threads;
+        std::vector<threading_model> threads;
         Iter workIter = data->cbegin();
         for (unsigned int i = 0; i < kernel->getNThreads() - 1; ++i) {
             std::promise<result_t> promise;

--- a/kernels/cpu_dense/include/readdy/kernel/cpu_dense/CPUDStateModel.h
+++ b/kernels/cpu_dense/include/readdy/kernel/cpu_dense/CPUDStateModel.h
@@ -77,6 +77,8 @@ public:
 
     virtual void clearNeighborList() override;
 
+    virtual void expected_n_particles(const std::size_t n) override;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> pimpl;

--- a/kernels/cpu_dense/include/readdy/kernel/cpu_dense/model/CPUDParticleData.h
+++ b/kernels/cpu_dense/include/readdy/kernel/cpu_dense/model/CPUDParticleData.h
@@ -109,6 +109,8 @@ public:
 
     std::size_t size() const;
 
+    void reserve(std::size_t n);
+
     std::size_t max_size() const;
 
     Entry& entry_at(const index_t);

--- a/kernels/cpu_dense/src/CPUDStateModel.cpp
+++ b/kernels/cpu_dense/src/CPUDStateModel.cpp
@@ -230,6 +230,13 @@ readdy::model::Particle CPUDStateModel::getParticleForIndex(const std::size_t in
     return pimpl->cdata().toParticle(pimpl->cdata().entry_at(index));
 }
 
+void CPUDStateModel::expected_n_particles(const std::size_t n) {
+    auto& data = pimpl->data();
+    if(data.size() < n) {
+        data.reserve(n);
+    }
+}
+
 CPUDStateModel::~CPUDStateModel() = default;
 
 

--- a/kernels/cpu_dense/src/model/CPUDParticleData.cpp
+++ b/kernels/cpu_dense/src/model/CPUDParticleData.cpp
@@ -241,6 +241,10 @@ void CPUDParticleData::deactivate(CPUDParticleData::index_t idx) {
     deactivate(entry_at(idx));
 }
 
+void CPUDParticleData::reserve(std::size_t n) {
+    entries.reserve(n);
+}
+
 CPUDParticleData::~CPUDParticleData() = default;
 
 }

--- a/kernels/singlecpu/src/SCPUStateModel.cpp
+++ b/kernels/singlecpu/src/SCPUStateModel.cpp
@@ -201,6 +201,12 @@ readdy::model::Particle SCPUStateModel::getParticleForIndex(const std::size_t in
     return pimpl->particleData->getParticle(index);
 }
 
+void SCPUStateModel::expected_n_particles(const std::size_t n) {
+    if(pimpl->particleData->size() < n) {
+        pimpl->particleData->reserve(n);
+    }
+}
+
 
 SCPUStateModel &SCPUStateModel::operator=(SCPUStateModel &&rhs) = default;
 

--- a/kernels/singlecpu/src/model/SCPUParticleData.cpp
+++ b/kernels/singlecpu/src/model/SCPUParticleData.cpp
@@ -202,6 +202,10 @@ SCPUParticleData::index_t SCPUParticleData::n_deactivated() const {
     return blanks.size();
 }
 
+void SCPUParticleData::reserve(std::size_t n) {
+    entries.reserve(n);
+}
+
 bool Entry::is_deactivated() const {
     return deactivated;
 }

--- a/readdy/main/Simulation.cpp
+++ b/readdy/main/Simulation.cpp
@@ -407,6 +407,11 @@ void Simulation::configureTopologyTorsionPotential(const std::string &type1, con
     );
 }
 
+void Simulation::setExpectedMaxNParticles(const std::size_t n) {
+    ensureKernelSelected();
+    getSelectedKernel()->expected_n_particles(n);
+}
+
 NoKernelSelectedException::NoKernelSelectedException(const std::string &__arg) : runtime_error(__arg) {};
 
 }

--- a/readdy/main/Simulation.cpp
+++ b/readdy/main/Simulation.cpp
@@ -235,8 +235,7 @@ Simulation &Simulation::operator=(Simulation &&rhs) = default;
 Simulation::Simulation(Simulation &&rhs) = default;
 
 Simulation::~Simulation() {
-    // close trajectory file if present
-    closeTrajectoryFile();
+    log::trace("destroying simulation");
 };
 
 const short
@@ -302,26 +301,6 @@ double Simulation::getRecommendedTimeStep(unsigned int N) const {
 
 readdy::model::Kernel *const Simulation::getSelectedKernel() const {
     return pimpl->kernel.get();
-}
-
-void
-Simulation::recordTrajectory(const std::string &fileName, const unsigned int stride, const unsigned int flushStride) {
-    ensureKernelSelected();
-    auto uuid = pimpl->counter++;
-    pimpl->trajectoryFileId = uuid;
-    pimpl->trajectoryFile.reset(new io::File(fileName, io::File::Action::CREATE));
-    std::unique_ptr<model::observables::Trajectory> trajectory = std::make_unique<model::observables::Trajectory>(
-            pimpl->kernel.get(), stride
-    );
-    trajectory->enableWriteToFile(*pimpl->trajectoryFile, "", flushStride);
-    auto &&connection = pimpl->kernel->connectObservable(trajectory.get());
-    pimpl->observables.emplace(uuid, std::move(trajectory));
-    pimpl->observableConnections.emplace(uuid, std::move(connection));
-}
-
-void Simulation::closeTrajectoryFile() {
-    deregisterObservable(pimpl->trajectoryFileId);
-    pimpl->trajectoryFile.reset();
 }
 
 const short Simulation::registerCompartmentSphere(const std::unordered_map<std::string, std::string> &conversionsMap,

--- a/readdy/main/common/Config.cpp
+++ b/readdy/main/common/Config.cpp
@@ -30,8 +30,9 @@
  */
 
 #include <thread>
+#include <algorithm>
+
 #include <readdy/common/logging.h>
-#include <readdy/common/macros.h>
 
 #include "readdy/common/thread/Config.h"
 
@@ -44,11 +45,11 @@ namespace util {
 namespace thread {
 
 Config::Config() {
-    // magic number 4 to enable some load balancing
 #ifdef READDY_DEBUG
-    m_nThreads = std::thread::hardware_concurrency();
+    m_nThreads = std::max(std::thread::hardware_concurrency(), 1u);
 #else
-    m_nThreads = 4*std::thread::hardware_concurrency();
+    // magic number 4 to enable some load balancing
+    m_nThreads = std::max(4*std::thread::hardware_concurrency(), 1u);
 #endif
 
     const char *env = std::getenv("READDY_N_CORES");

--- a/readdy/main/model/Kernel.cpp
+++ b/readdy/main/model/Kernel.cpp
@@ -223,7 +223,15 @@ TopologyParticle Kernel::createTopologyParticle(const std::string &type, const V
 }
 
 bool Kernel::supportsTopologies() const {
-    return getTopologyActionFactory() ? true : false;
+    return getTopologyActionFactory() != nullptr;
+}
+
+void Kernel::expected_n_particles(const std::size_t n) {
+    if(n >= 0) {
+        getKernelStateModel().expected_n_particles(n);
+    } else {
+        throw std::invalid_argument("expected number of particles should be larger than 0");
+    }
 }
 
 Kernel &Kernel::operator=(Kernel &&rhs) = default;

--- a/readdy/main/model/Kernel.cpp
+++ b/readdy/main/model/Kernel.cpp
@@ -61,6 +61,7 @@ Kernel::Kernel(const std::string &name) : pimpl(std::make_unique<Kernel::Impl>()
 }
 
 Kernel::~Kernel() {
+    log::trace("destroying kernel instance");
 }
 
 readdy::signals::scoped_connection Kernel::connectObservable(observables::ObservableBase *const observable) {

--- a/readdy/test/TestPerformance.cpp
+++ b/readdy/test/TestPerformance.cpp
@@ -542,7 +542,7 @@ void scaleNumbersAndSkin(const std::string kernelName, bool reducedNumbers) {
     double relativeDisplacement[numbersSize][skinSizesSize];
     double reactivity[numbersSize][skinSizesSize];
 
-    readdy::log::console()->set_level(spdlog::level::debug);
+    readdy::log::console()->set_level(spdlog::level::warn);
     for (auto i = 0; i < numbersSize; ++i) {
         for (auto j = 0; j < skinSizesSize; ++j) {
             readdy::log::error("at numbers {} / {} = {}, skins {} / {} = {}", i, numbersSize, numbers[i], j,

--- a/readdy/test/TestPerformance.cpp
+++ b/readdy/test/TestPerformance.cpp
@@ -68,6 +68,7 @@
 #include <readdy/plugin/KernelProvider.h>
 #include <readdy/model/Utils.h>
 #include <readdy/io/File.h>
+#include <readdy/api/Simulation.h>
 
 namespace {
 
@@ -650,8 +651,23 @@ void scaleNumbersAndSkin_tmp(const std::string kernelName, bool reducedNumbers) 
 TEST(TestPerformance, ReactiveCPU) {
     //scaleNumbersAndSkin<CollisiveUniformHomogeneous, readdy::model::actions::reactions::Gillespie>("SingleCPU", true);
     //scaleNumbersAndSkin<CollisiveUniformHomogeneous, readdy::model::actions::reactions::GillespieParallel>("CPU_Dense", false);
-    scaleNumbersAndSkin<ReactiveCollisiveUniformHomogeneous, readdy::model::actions::reactions::GillespieParallel>(
-            "CPU", false);
+    //scaleNumbersAndSkin<ReactiveCollisiveUniformHomogeneous, readdy::model::actions::reactions::GillespieParallel>(
+            //"CPU", false);
+    readdy::Simulation sim;
+    sim.setKernel("CPU");
+    sim.setBoxSize(100, 100, 100);
+    sim.setPeriodicBoundary({true, true, true});
+    sim.registerParticleType("A", 1.0, 1.0);
+    for(int i = 0; i < 200; ++i) {
+        sim.addParticle(0, 0, 0, "A");
+    }
+    readdy::log::console()->set_level(spdlog::level::debug);
+    {
+        using timer = readdy::util::Timer;
+        timer c {"timer"};
+        sim.runScheme(true).includeForces(false).evaluateObservables(false).configureAndRun(1, 100000);
+    }
+
 }
 
 }

--- a/wrappers/python/src/cxx/api/ApiModule.cpp
+++ b/wrappers/python/src/cxx/api/ApiModule.cpp
@@ -63,6 +63,7 @@ enum class ParticleTypeFlavor {
 };
 
 void exportApi(py::module &api) {
+    using namespace pybind11::literals;
     exportSchemeApi<readdy::api::ReaDDyScheme>(api, "ReaDDyScheme");
     exportSchemeApi<readdy::api::AdvancedScheme>(api, "AdvancedScheme");
 
@@ -83,6 +84,7 @@ void exportApi(py::module &api) {
             .def_property("kbt", &sim::getKBT, &sim::setKBT)
             .def_property("periodic_boundary", &sim::getPeriodicBoundary, &sim::setPeriodicBoundary)
             .def_property("box_size", &sim::getBoxSize, &setBoxSize)
+            .def("set_expected_max_n_particles", &sim::setExpectedMaxNParticles, "n"_a)
             .def("register_particle_type",
                  [](sim &self, const std::string &name, double diffusionCoefficient, double radius,
                     ParticleTypeFlavor flavor) {
@@ -97,73 +99,87 @@ void exportApi(py::module &api) {
                          }
                      }();
                      return self.registerParticleType(name, diffusionCoefficient, radius);
-                 }, py::arg("name"), py::arg("diffusion_coefficient"), py::arg("radius"),
-                 py::arg("flavor") = ParticleTypeFlavor::NORMAL)
+                 }, "name"_a, "diffusion_coefficient"_a, "radius"_a, "flavor"_a = ParticleTypeFlavor::NORMAL)
             .def("add_particle", [](sim &self, const std::string &type, const vec &pos) {
                 self.addParticle(pos[0], pos[1], pos[2], type);
-            })
+            }, "type"_a, "pos"_a)
             .def("is_kernel_selected", &sim::isKernelSelected)
             .def("get_selected_kernel_type", &getSelectedKernelType)
-            .def("record_trajectory", &sim::recordTrajectory)
+            .def("record_trajectory", &sim::recordTrajectory, "file_name"_a, "stride"_a, "chunk_size"_a)
             .def("close_trajectory_file", &sim::closeTrajectoryFile)
-            .def("register_potential_order_2", &registerPotentialOrder2)
-            .def("register_potential_harmonic_repulsion", &sim::registerHarmonicRepulsionPotential)
+            .def("register_potential_order_2", &registerPotentialOrder2, "potential"_a)
+            .def("register_potential_harmonic_repulsion", &sim::registerHarmonicRepulsionPotential,
+                 "type_a"_a, "type_b"_a, "force_constant"_a)
             .def("register_potential_piecewise_weak_interaction",
-                 &sim::registerWeakInteractionPiecewiseHarmonicPotential)
-            .def("register_potential_box", &sim::registerBoxPotential)
-            .def("register_potential_sphere_in", &sim::registerSphereInPotential)
-            .def("register_potential_sphere_out", &sim::registerSphereOutPotential)
-            .def("register_potential_lennard_jones", &sim::registerLennardJonesPotential)
-            .def("register_potential_screened_electrostatics", &sim::registerScreenedElectrostaticsPotential)
+                 &sim::registerWeakInteractionPiecewiseHarmonicPotential, "type_a"_a, "type_b"_a, "force_constant"_a,
+                 "desired_particle_distance"_a, "depth"_a, "no_interaction_distance"_a)
+            .def("register_potential_box", &sim::registerBoxPotential, "particle_type"_a, "force_constant"_a,
+                 "origin"_a, "extent"_a, "consider_particle_radius"_a)
+            .def("register_potential_sphere_in", &sim::registerSphereInPotential, "particle_type"_a, "force_constant"_a,
+                 "origin"_a, "radius"_a)
+            .def("register_potential_sphere_out", &sim::registerSphereOutPotential, "particle_type"_a,
+                 "force_constant"_a, "origin"_a, "radius"_a)
+            .def("register_potential_lennard_jones", &sim::registerLennardJonesPotential, "particle_type_a"_a,
+                 "particle_type_b"_a, "exponent_m"_a, "exponent_n"_a, "cutoff"_a, "shift"_a, "epsilon"_a, "sigma"_a)
+            .def("register_potential_screened_electrostatics", &sim::registerScreenedElectrostaticsPotential,
+                 "particle_type_a"_a, "particle_type_b"_a, "electrostatic_strength"_a, "inverse_screening_depth"_a,
+                 "repulsion_strength"_a, "repulsion_distance"_a, "exponent"_a, "cutoff"_a)
             .def("get_particle_positions", &sim::getParticlePositions)
-            .def("register_reaction_conversion", &sim::registerConversionReaction, rvp::reference_internal)
-            .def("register_reaction_enzymatic", &sim::registerEnzymaticReaction, rvp::reference_internal)
-            .def("register_reaction_fission", &sim::registerFissionReaction, rvp::reference_internal)
-            .def("register_reaction_fusion", &sim::registerFusionReaction, rvp::reference_internal)
-            .def("register_reaction_decay", &sim::registerDecayReaction, rvp::reference_internal)
-            .def("register_compartment_sphere", &sim::registerCompartmentSphere)
-            .def("register_compartment_plane", &sim::registerCompartmentPlane)
-            .def("get_recommended_time_step", &sim::getRecommendedTimeStep)
+            .def("register_reaction_conversion", &sim::registerConversionReaction, rvp::reference_internal,
+                 "label"_a, "from_type"_a, "to_type"_a, "rate"_a)
+            .def("register_reaction_enzymatic", &sim::registerEnzymaticReaction, rvp::reference_internal,
+                 "label"_a, "catalyst_type"_a, "from_type"_a, "to_type"_a, "rate"_a, "educt_distance"_a)
+            .def("register_reaction_fission", &sim::registerFissionReaction, rvp::reference_internal,
+                 "label"_a, "from_type"_a, "to_type1"_a, "to_type2"_a, "rate"_a, "product_distance"_a,
+                 "weight1"_a = .5, "weight2"_a = .5)
+            .def("register_reaction_fusion", &sim::registerFusionReaction, rvp::reference_internal, "label"_a,
+                 "from_type1"_a, "from_type2"_a, "to_type"_a, "rate"_a, "educt_distance"_a,
+                 "weight1"_a = .5, "weight2"_a = .5)
+            .def("register_reaction_decay", &sim::registerDecayReaction, rvp::reference_internal,
+                 "label"_a, "particle_type"_a, "rate"_a)
+            .def("register_compartment_sphere", &sim::registerCompartmentSphere,
+                 "conversion_map"_a, "name"_a, "origin"_a, "radius"_a, "larger_or_less"_a)
+            .def("register_compartment_plane", &sim::registerCompartmentPlane, "conversion_map"_a, "name"_a,
+                 "normal_coefficients"_a, "distance_from_plane"_a, "larger_or_less"_a)
+            .def("get_recommended_time_step", &sim::getRecommendedTimeStep, "n"_a)
             .def("kernel_supports_topologies", &sim::kernelSupportsTopologies)
-            .def("create_topology_particle", &sim::createTopologyParticle)
-            .def("configure_topology_bond_potential", &sim::configureTopologyBondPotential, py::arg("type1"),
-                 py::arg("type2"), py::arg("force_constant"), py::arg("length"),
-                 py::arg("type") = readdy::api::BondType::HARMONIC)
-            .def("configure_topology_angle_potential", &sim::configureTopologyAnglePotential, py::arg("type1"),
-                 py::arg("type2"), py::arg("type3"), py::arg("force_constant"), py::arg("equilibrium_angle"),
-                 py::arg("type") = readdy::api::AngleType::HARMONIC)
-            .def("configure_topology_dihedral_potential", &sim::configureTopologyTorsionPotential, py::arg("type1"),
-                 py::arg("type2"), py::arg("type3"), py::arg("type4"), py::arg("force_constant"),
-                 py::arg("multiplicity"), py::arg("phi_0"), py::arg("type") = readdy::api::TorsionType::COS_DIHEDRAL)
-            .def("add_topology", &sim::addTopology, rvp::reference, py::arg("particles"),
-                 py::arg("labels") = std::vector<std::string>())
-            .def("set_kernel", &sim::setKernel)
+            .def("create_topology_particle", &sim::createTopologyParticle, "type"_a, "position"_a)
+            .def("configure_topology_bond_potential", &sim::configureTopologyBondPotential, "type1"_a, "type2"_a,
+                 "force_constant"_a, "length"_a, "type"_a = readdy::api::BondType::HARMONIC)
+            .def("configure_topology_angle_potential", &sim::configureTopologyAnglePotential, "type1"_a, "type2"_a,
+                 "type3"_a, "force_constant"_a, "equilibrium_angle"_a, "type"_a = readdy::api::AngleType::HARMONIC)
+            .def("configure_topology_dihedral_potential", &sim::configureTopologyTorsionPotential, "type1"_a,
+                 "type2"_a, "type3"_a, "type4"_a, "force_constant"_a, "multiplicity"_a, "phi_0"_a,
+                 "type"_a = readdy::api::TorsionType::COS_DIHEDRAL)
+            .def("add_topology", &sim::addTopology, rvp::reference, "particles"_a,
+                 "labels"_a = std::vector<std::string>())
+            .def("set_kernel", &sim::setKernel, "name"_a)
             .def("run_scheme_readdy", [](sim &self, bool defaults) {
                      return std::make_unique<readdy::api::SchemeConfigurator<readdy::api::ReaDDyScheme>>(
                              self.runScheme<readdy::api::ReaDDyScheme>(defaults)
                      );
-                 }, py::arg("defaults")
+                 }, "defaults"_a
             )
             .def("run_scheme_advanced", [](sim &self, bool defaults) {
                      return std::make_unique<readdy::api::SchemeConfigurator<readdy::api::AdvancedScheme>>(
                              self.runScheme<readdy::api::AdvancedScheme>(defaults)
                      );
-                 }, py::arg("defaults")
+                 }, "defaults"_a
             )
             .def("run", [](sim &self, const readdy::time_step_type steps, const double timeStep) {
                 py::gil_scoped_release release;
                 self.run(steps, timeStep);
-            });
+            }, "n_steps"_a, "time_step"_a);
     exportObservables(api, simulation);
 
     py::class_<kp, std::unique_ptr<kp, readdy::util::nodelete>>(api, "KernelProvider")
             .def_static("get", &kp::getInstance, rvp::reference)
-            .def("load_from_dir", &kp::loadKernelsFromDirectory);
+            .def("load_from_dir", &kp::loadKernelsFromDirectory, "directory"_a);
 
     py::class_<pot2>(api, "Pot2")
             .def(py::init<std::string, std::string, py::object, py::object>())
-            .def("calc_energy", &pot2::calculateEnergy)
-            .def("calc_force", &pot2::calculateForce);
+            .def("calc_energy", &pot2::calculateEnergy, "x_ij"_a)
+            .def("calc_force", &pot2::calculateForce, "force"_a, "x_ij"_a);
 
     py::class_<kern>(api, "Kernel").def("get_name", &kern::getName, rvp::reference);
 }

--- a/wrappers/python/src/cxx/api/ApiModule.cpp
+++ b/wrappers/python/src/cxx/api/ApiModule.cpp
@@ -105,8 +105,6 @@ void exportApi(py::module &api) {
             }, "type"_a, "pos"_a)
             .def("is_kernel_selected", &sim::isKernelSelected)
             .def("get_selected_kernel_type", &getSelectedKernelType)
-            .def("record_trajectory", &sim::recordTrajectory, "file_name"_a, "stride"_a, "chunk_size"_a)
-            .def("close_trajectory_file", &sim::closeTrajectoryFile)
             .def("register_potential_order_2", &registerPotentialOrder2, "potential"_a)
             .def("register_potential_harmonic_repulsion", &sim::registerHarmonicRepulsionPotential,
                  "type_a"_a, "type_b"_a, "force_constant"_a)

--- a/wrappers/python/src/cxx/api/ExportObservables.h
+++ b/wrappers/python/src/cxx/api/ExportObservables.h
@@ -45,7 +45,8 @@ using rvp = py::return_value_policy;
 using sim = readdy::Simulation;
 using obs_handle_t = readdy::ObservableHandle;
 
-inline obs_handle_t registerObservable_Reactions(sim &self, unsigned int stride, py::object callback) {
+inline obs_handle_t registerObservable_Reactions(sim &self, unsigned int stride,
+                                                 const py::object& callback = py::none()) {
     if (callback.is_none()) {
         return self.registerObservable<readdy::model::observables::Reactions>(stride);
     } else {
@@ -54,7 +55,8 @@ inline obs_handle_t registerObservable_Reactions(sim &self, unsigned int stride,
     }
 }
 
-inline obs_handle_t registerObservable_ReactionCounts(sim &self, unsigned int stride, py::object callback) {
+inline obs_handle_t registerObservable_ReactionCounts(sim &self, unsigned int stride,
+                                                      const py::object& callback = py::none()) {
     if (callback.is_none()) {
         return self.registerObservable<readdy::model::observables::ReactionCounts>(stride);
     } else {
@@ -64,8 +66,8 @@ inline obs_handle_t registerObservable_ReactionCounts(sim &self, unsigned int st
 }
 
 inline obs_handle_t
-registerObservable_Positions(sim &self, unsigned int stride, pybind11::object callbackFun,
-                             std::vector<std::string> types) {
+registerObservable_Positions(sim &self, unsigned int stride,
+                             std::vector<std::string> types, const pybind11::object& callbackFun = py::none()) {
     if (callbackFun.is_none()) {
         return self.registerObservable<readdy::model::observables::Positions>(stride, types);
     } else {
@@ -74,7 +76,8 @@ registerObservable_Positions(sim &self, unsigned int stride, pybind11::object ca
     }
 }
 
-inline obs_handle_t registerObservable_Particles(sim &self, unsigned int stride, pybind11::object callbackFun) {
+inline obs_handle_t registerObservable_Particles(sim &self, unsigned int stride,
+                                                 const pybind11::object& callbackFun = py::none()) {
     if (callbackFun.is_none()) {
         return self.registerObservable<readdy::model::observables::Particles>(stride);
     } else {
@@ -85,9 +88,9 @@ inline obs_handle_t registerObservable_Particles(sim &self, unsigned int stride,
 
 
 inline obs_handle_t
-registerObservable_RadialDistribution(sim &self, unsigned int stride, pybind11::object callbackFun,
-                                      py::array_t<double> &binBorders, std::vector<std::string> typeCountFrom,
-                                      std::vector<std::string> typeCountTo, double particleToDensity) {
+registerObservable_RadialDistribution(sim &self, unsigned int stride, py::array_t<double> &binBorders,
+                                      std::vector<std::string> typeCountFrom, std::vector<std::string> typeCountTo,
+                                      double particleToDensity, const pybind11::object& callbackFun = py::none()) {
     const auto info = binBorders.request();
     std::vector<double> binBordersVec{};
     binBordersVec.reserve(info.shape[0]);
@@ -107,8 +110,8 @@ registerObservable_RadialDistribution(sim &self, unsigned int stride, pybind11::
 }
 
 inline obs_handle_t
-registerObservable_CenterOfMass(sim &self, unsigned int stride, const pybind11::object &callbackFun,
-                                std::vector<std::string> types) {
+registerObservable_CenterOfMass(sim &self, unsigned int stride, std::vector<std::string> types,
+                                const pybind11::object &callbackFun = py::none()) {
     if (callbackFun.is_none()) {
         return self.registerObservable<readdy::model::observables::CenterOfMass>(stride, types);
     } else {
@@ -120,9 +123,9 @@ registerObservable_CenterOfMass(sim &self, unsigned int stride, const pybind11::
 }
 
 inline obs_handle_t
-registerObservable_HistogramAlongAxisObservable(sim &self, unsigned int stride, const py::object &callbackFun,
-                                                py::array_t<double> binBorders, unsigned int axis,
-                                                std::vector<std::string> types) {
+registerObservable_HistogramAlongAxisObservable(sim &self, unsigned int stride, py::array_t<double> binBorders,
+                                                unsigned int axis, std::vector<std::string> types,
+                                                const py::object &callbackFun = py::none()) {
     const auto info = binBorders.request();
     const auto sizeBorders = info.shape[0];
     auto binBordersData = static_cast<double *>(info.ptr);
@@ -144,8 +147,8 @@ registerObservable_HistogramAlongAxisObservable(sim &self, unsigned int stride, 
 }
 
 inline obs_handle_t
-registerObservable_NParticles(sim &self, unsigned int stride, const py::object &callbackFun,
-                              std::vector<std::string> types) {
+registerObservable_NParticles(sim &self, unsigned int stride, std::vector<std::string> types,
+                              const py::object &callbackFun = py::none()) {
     if (callbackFun.is_none()) {
         return self.registerObservable<readdy::model::observables::NParticles>(stride, types);
     } else {
@@ -154,8 +157,8 @@ registerObservable_NParticles(sim &self, unsigned int stride, const py::object &
     }
 }
 
-inline obs_handle_t registerObservable_ForcesObservable(sim &self, unsigned int stride, py::object callbackFun,
-                                                 std::vector<std::string> types) {
+inline obs_handle_t registerObservable_ForcesObservable(sim &self, unsigned int stride, std::vector<std::string> types,
+                                                        const py::object& callbackFun = py::none()) {
     if (callbackFun.is_none()) {
         return self.registerObservable<readdy::model::observables::Forces>(stride, types);
     } else {
@@ -170,9 +173,10 @@ inline obs_handle_t registerObservable_Trajectory(sim& self, unsigned int stride
 
 template <typename type_, typename... options>
 void exportObservables(py::module &apiModule, py::class_<type_, options...> &simulation) {
+    using namespace pybind11::literals;
     py::class_<obs_handle_t>(apiModule, "ObservableHandle")
             .def(py::init<>())
-            .def("enable_write_to_file", &obs_handle_t::enableWriteToFile)
+            .def("enable_write_to_file", &obs_handle_t::enableWriteToFile, "file"_a, "data_set_name"_a, "chunk_size"_a)
             .def("flush", &obs_handle_t::flush)
             .def("__repr__", [](const obs_handle_t &self) {
                 return "ObservableHandle(id=" + std::to_string(self.getId()) + ")";
@@ -192,18 +196,26 @@ void exportObservables(py::module &apiModule, py::class_<type_, options...> &sim
                 return ss.str();
             });
 
-    simulation.def("register_observable_particle_positions", &registerObservable_Positions)
-            .def("register_observable_particles", &registerObservable_Particles)
-            .def("register_observable_radial_distribution", &registerObservable_RadialDistribution)
-            .def("register_observable_histogram_along_axis", &registerObservable_HistogramAlongAxisObservable)
-            .def("register_observable_center_of_mass", &registerObservable_CenterOfMass)
-            .def("register_observable_n_particles", &registerObservable_NParticles)
-            .def("register_observable_forces", &registerObservable_ForcesObservable)
-            .def("register_observable_reactions", &registerObservable_Reactions)
-            .def("register_observable_reaction_counts", &registerObservable_ReactionCounts)
-            .def("register_observable_trajectory", &registerObservable_Trajectory)
+    simulation.def("register_observable_particle_positions", &registerObservable_Positions,
+                   "stride"_a, "types"_a, "callback"_a = py::none())
+            .def("register_observable_particles", &registerObservable_Particles, "stride"_a, "callback"_a = py::none())
+            .def("register_observable_radial_distribution", &registerObservable_RadialDistribution,
+                 "stride"_a, "bin_borders"_a, "type_count_from"_a, "type_count_to"_a,
+                 "particle_to_density"_a, "callback"_a = py::none())
+            .def("register_observable_histogram_along_axis", &registerObservable_HistogramAlongAxisObservable,
+                 "stride"_a, "bin_borders"_a, "axis"_a, "types"_a, "callback"_a = py::none())
+            .def("register_observable_center_of_mass", &registerObservable_CenterOfMass,
+                 "stride"_a, "types"_a, "callback"_a = py::none())
+            .def("register_observable_n_particles", &registerObservable_NParticles,
+                 "stride"_a, "types"_a, "callback"_a = py::none())
+            .def("register_observable_forces", &registerObservable_ForcesObservable,
+                 "stride"_a, "types"_a, "callback"_a = py::none())
+            .def("register_observable_reactions", &registerObservable_Reactions, "stride"_a, "callback"_a = py::none())
+            .def("register_observable_reaction_counts", &registerObservable_ReactionCounts,
+                 "stride"_a, "callback"_a = py::none())
+            .def("register_observable_trajectory", &registerObservable_Trajectory, "stride"_a)
             .def("deregister_observable", [](sim &self, const obs_handle_t &handle) {
                 self.deregisterObservable(handle.getId());
-            });
+            }, "handle"_a);
 }
 #endif //READDY_MAIN_EXPORTOBSERVABLES_H

--- a/wrappers/python/src/cxx/api/ExportSchemeApi.h
+++ b/wrappers/python/src/cxx/api/ExportSchemeApi.h
@@ -40,69 +40,74 @@
 template<typename SchemeType>
 void exportSchemeApi(pybind11::module &module, std::string schemeName) {
     namespace py = pybind11;
+    using namespace py::literals;
     using conf = readdy::api::SchemeConfigurator<SchemeType>;
     py::class_<SchemeType>(module, schemeName.c_str())
             .def("run", [](SchemeType& self, const readdy::time_step_type steps) {
                 py::gil_scoped_release release;
                 self.run(steps);
-            })
+            }, "n_steps"_a)
             .def("run_with_criterion", [](SchemeType& self, pybind11::object continuingCriterion) {
                 py::gil_scoped_release release;
                 auto pyFun = readdy::rpy::PyFunction<bool(const readdy::time_step_type current)>(continuingCriterion);
                 self.run(std::move(pyFun));
-            });
+            }, "continuing_criterion"_a);
     std::string configuratorName =  schemeName + "Configurator";
     py::class_<conf>(module, configuratorName.c_str())
             .def("with_integrator",
                  [](conf &self, std::string name) -> conf & { return self.withIntegrator(name); },
-                 py::return_value_policy::reference_internal)
-            .def("include_forces", &conf::includeForces, py::return_value_policy::reference_internal)
+                 py::return_value_policy::reference_internal, "integrator_name"_a)
+            .def("include_forces", &conf::includeForces, py::return_value_policy::reference_internal,
+                 "do_include"_a = true)
             .def("with_reaction_scheduler",
                  [](conf &self, std::string name) -> conf & {
                      return (self.withReactionScheduler(name));
                  },
-                 py::return_value_policy::reference_internal)
-            .def("evaluate_observables", &conf::evaluateObservables, py::return_value_policy::reference_internal)
-            .def("configure", &conf::configure)
+                 py::return_value_policy::reference_internal, "reaction_scheduler_name"_a)
+            .def("evaluate_observables", &conf::evaluateObservables, py::return_value_policy::reference_internal,
+                 "do_evaluate"_a = true)
+            .def("configure", &conf::configure, "time_step"_a)
             .def("configure_and_run", [](conf& self, double dt, const readdy::time_step_type steps) {
                 py::gil_scoped_release release;
                 self.configureAndRun(dt, steps);
-            });
+            }, "time_step"_a, "n_time_steps"_a);
 }
 
 template<>
 void exportSchemeApi<readdy::api::AdvancedScheme>(pybind11::module &module, std::string schemeName) {
     namespace py = pybind11;
+    using namespace py::literals;
     using scheme_t = readdy::api::AdvancedScheme;
     using conf = readdy::api::SchemeConfigurator<scheme_t>;
     py::class_<scheme_t>(module, schemeName.c_str())
             .def("run", [](scheme_t& self, const readdy::time_step_type steps) {
                 py::gil_scoped_release release;
                 self.run(steps);
-            })
+            }, "n_steps"_a)
             .def("run_with_criterion", [](scheme_t& self, pybind11::object continuingCriterion) {
                 py::gil_scoped_release release;
                 auto pyFun = readdy::rpy::PyFunction<bool(const readdy::time_step_type current)>(continuingCriterion);
                 self.run(std::move(pyFun));
-            });
+            }, "continue_criterion"_a);
     std::string configuratorName =  schemeName + "Configurator";
     py::class_<conf>(module, configuratorName.c_str())
             .def("with_integrator",
                  [](conf &self, std::string name) -> conf & { return self.withIntegrator(name); },
-                 py::return_value_policy::reference_internal)
-            .def("include_forces", &conf::includeForces, py::return_value_policy::reference_internal)
-            .def("include_compartments", &conf::includeCompartments, py::return_value_policy::reference_internal)
+                 py::return_value_policy::reference_internal, "integrator_name"_a)
+            .def("include_forces", &conf::includeForces, py::return_value_policy::reference_internal, "do_include"_a = true)
+            /* fixme @chrisfroe: see comment in SimulationScheme.h */
+            .def("include_compartments", &conf::includeCompartments, py::return_value_policy::reference_internal, "do_include"_a = true)
             .def("with_reaction_scheduler",
                  [](conf &self, std::string name) -> conf & {
                      return (self.withReactionScheduler(name));
                  },
-                 py::return_value_policy::reference_internal)
-            .def("evaluate_observables", &conf::evaluateObservables, py::return_value_policy::reference_internal)
-            .def("configure", &conf::configure)
+                 py::return_value_policy::reference_internal, "reaction_scheduler_name"_a)
+            .def("evaluate_observables", &conf::evaluateObservables, py::return_value_policy::reference_internal, "do_evaluate"_a = true)
+            .def("configure", &conf::configure, "time_step"_a)
             .def("configure_and_run", [](conf& self, double dt, const readdy::time_step_type steps) {
                 py::gil_scoped_release release;
                 self.configureAndRun(dt, steps);
-            });
+            }, "time_step"_a, "n_time_steps"_a);
 };
 
 #endif //READDY_MAIN_EXPORTSCHEMEAPI_H

--- a/wrappers/python/src/cxx/api/ExportSchemeApi.h
+++ b/wrappers/python/src/cxx/api/ExportSchemeApi.h
@@ -96,7 +96,6 @@ void exportSchemeApi<readdy::api::AdvancedScheme>(pybind11::module &module, std:
                  [](conf &self, std::string name) -> conf & { return self.withIntegrator(name); },
                  py::return_value_policy::reference_internal, "integrator_name"_a)
             .def("include_forces", &conf::includeForces, py::return_value_policy::reference_internal, "do_include"_a = true)
-            /* fixme @chrisfroe: see comment in SimulationScheme.h */
             .def("include_compartments", &conf::includeCompartments, py::return_value_policy::reference_internal, "do_include"_a = true)
             .def("with_reaction_scheduler",
                  [](conf &self, std::string name) -> conf & {

--- a/wrappers/python/src/cxx/api/ExportSchemeApi.h
+++ b/wrappers/python/src/cxx/api/ExportSchemeApi.h
@@ -66,6 +66,7 @@ void exportSchemeApi(pybind11::module &module, std::string schemeName) {
                  py::return_value_policy::reference_internal, "reaction_scheduler_name"_a)
             .def("evaluate_observables", &conf::evaluateObservables, py::return_value_policy::reference_internal,
                  "do_evaluate"_a = true)
+            .def("with_skin_size", &conf::withSkinSize, py::return_value_policy::reference_internal, "skin_size"_a = -1)
             .def("configure", &conf::configure, "time_step"_a)
             .def("configure_and_run", [](conf& self, double dt, const readdy::time_step_type steps) {
                 py::gil_scoped_release release;
@@ -103,6 +104,7 @@ void exportSchemeApi<readdy::api::AdvancedScheme>(pybind11::module &module, std:
                  },
                  py::return_value_policy::reference_internal, "reaction_scheduler_name"_a)
             .def("evaluate_observables", &conf::evaluateObservables, py::return_value_policy::reference_internal, "do_evaluate"_a = true)
+            .def("with_skin_size", &conf::withSkinSize, py::return_value_policy::reference_internal, "skin_size"_a = -1)
             .def("configure", &conf::configure, "time_step"_a)
             .def("configure_and_run", [](conf& self, double dt, const readdy::time_step_type steps) {
                 py::gil_scoped_release release;

--- a/wrappers/python/src/python/readdy/examples/min-e_min-d.py
+++ b/wrappers/python/src/python/readdy/examples/min-e_min-d.py
@@ -297,20 +297,19 @@ class MinEMinDSimulation(object):
         self.stride = stride
         print("using stride=%s" % stride)
         bins = np.linspace(-7, 7, 80)
-        simulation.register_observable_histogram_along_axis(stride, self.histogram_callback_minD, bins, 2, ["D"])
-        simulation.register_observable_histogram_along_axis(stride, self.histogram_callback_minDP, bins, 2, ["D_P"])
-        simulation.register_observable_histogram_along_axis(stride, self.histogram_callback_minDPB, bins, 2, ["D_PB"])
-        simulation.register_observable_histogram_along_axis(stride, self.histogram_callback_minE, bins, 2, ["E"])
-        simulation.register_observable_histogram_along_axis(stride, self.histogram_callback_minDE, bins, 2, ["DE"])
-        simulation.register_observable_histogram_along_axis(stride, self.histogram_callback_M, bins, 2, ["D", "D_P", "D_PB", "DE"])
-        simulation.register_observable_n_particles(stride, self.n_particles_callback, ["D", "D_P", "D_PB", "E", "DE"])
+        simulation.register_observable_histogram_along_axis(stride, bins, 2, ["D"], self.histogram_callback_minD)
+        simulation.register_observable_histogram_along_axis(stride, bins, 2, ["D_P"], self.histogram_callback_minDP)
+        simulation.register_observable_histogram_along_axis(stride, bins, 2, ["D_PB"], self.histogram_callback_minDPB)
+        simulation.register_observable_histogram_along_axis(stride, bins, 2, ["E"], self.histogram_callback_minE)
+        simulation.register_observable_histogram_along_axis(stride, bins, 2, ["DE"], self.histogram_callback_minDE)
+        simulation.register_observable_histogram_along_axis(stride, bins, 2, ["D", "D_P", "D_PB", "DE"], self.histogram_callback_M)
+        simulation.register_observable_n_particles(stride, ["D", "D_P", "D_PB", "E", "DE"], self.n_particles_callback)
         print("histogram end")
 
         self.n_timesteps = int(1200./self.timestep)
 
         print("starting simulation for effectively %s sec" % (self.timestep * self.n_timesteps))
-        simulation.set_time_step(self.timestep)
-        simulation.run_scheme_readdy(True).with_reaction_scheduler("GillespieParallel").configure().run(self.n_timesteps)
+        simulation.run_scheme_readdy(True).with_reaction_scheduler("GillespieParallel").configure(self.timestep).run(self.n_timesteps)
 
         if self._result_fname is not None:
             with open(self._result_fname, 'w') as f:

--- a/wrappers/python/src/python/readdy/examples/two_particles_mini_example.py
+++ b/wrappers/python/src/python/readdy/examples/two_particles_mini_example.py
@@ -92,7 +92,7 @@ class TwoParticlesMiniExample(object):
         self.simulation.register_potential_box("C", 100., Vec(-.75, -.75, -.75), Vec(1.5, 1.5, 1.5), False)
         self.simulation.add_particle("A", Vec(-.0, -.0, -.0))
         self.simulation.add_particle("B", Vec(0.1, 0.1, 0.1))
-        self.simulation.register_observable_particle_positions(1, self.ppos_callback, [])
+        self.simulation.register_observable_particle_positions(1, [], self.ppos_callback)
 
         self.simulation.run(self.T, .0001)
 

--- a/wrappers/python/src/python/readdy/examples/two_particles_radial_distribution.py
+++ b/wrappers/python/src/python/readdy/examples/two_particles_radial_distribution.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     simulation.add_particle("A", Vec(-2.5, 0, 0))
     simulation.add_particle("B", Vec(0, 0, 0))
 
-    simulation.register_observable_radial_distribution(10, rdf_callback, np.arange(0, 5, .01), ["A"], ["B"], 1. / (box_size[0] * box_size[1] * box_size[2]))
+    simulation.register_observable_radial_distribution(10, np.arange(0, 5, .01), ["A"], ["B"], 1. / (box_size[0] * box_size[1] * box_size[2]), rdf_callback)
     simulation.run(T, 0.02)
 
     print("n_calls=%s" % n_calls)

--- a/wrappers/python/src/python/readdy/tests/test_io.py
+++ b/wrappers/python/src/python/readdy/tests/test_io.py
@@ -57,9 +57,10 @@ class TestSchemeApi(unittest.TestCase):
             simulation.add_particle("A", common.Vec(0, 0, 0))
 
         simulation.register_observable_n_particles(1, ["A"], callback)
-        simulation.record_trajectory(traj_fname, 0, 3)
-        simulation.run_scheme_readdy(True).configure(1).run(20)
-        simulation.close_trajectory_file()
+        traj_handle = simulation.register_observable_trajectory(0)
+        with closing(io.File(traj_fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
+            traj_handle.enable_write_to_file(f, u"", 3)
+            simulation.run_scheme_readdy(True).configure(1).run(20)
 
         r = TrajectoryReader(traj_fname)
         trajectory_items = r[:]

--- a/wrappers/python/src/python/readdy/tests/test_io.py
+++ b/wrappers/python/src/python/readdy/tests/test_io.py
@@ -56,7 +56,7 @@ class TestSchemeApi(unittest.TestCase):
         def callback(_):
             simulation.add_particle("A", common.Vec(0, 0, 0))
 
-        simulation.register_observable_n_particles(1, callback, ["A"])
+        simulation.register_observable_n_particles(1, ["A"], callback)
         simulation.record_trajectory(traj_fname, 0, 3)
         simulation.run_scheme_readdy(True).configure(1).run(20)
         simulation.close_trajectory_file()
@@ -82,7 +82,7 @@ class TestSchemeApi(unittest.TestCase):
         def callback(_):
             simulation.add_particle("A", common.Vec(0, 0, 0))
 
-        simulation.register_observable_n_particles(1, callback, ["A"])
+        simulation.register_observable_n_particles(1, ["A"], callback)
         traj_handle = simulation.register_observable_trajectory(1)
 
         with closing(io.File(traj_fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:

--- a/wrappers/python/src/python/readdy/tests/test_observables_io.py
+++ b/wrappers/python/src/python/readdy/tests/test_observables_io.py
@@ -59,8 +59,8 @@ class TestObservablesIO(unittest.TestCase):
         sim.register_particle_type("A", .1, .1)
         sim.add_particle("A", common.Vec(0, 0, 0))
         # every time step, add one particle
-        sim.register_observable_n_particles(1, lambda n: sim.add_particle("A", common.Vec(1.5, 2.5, 3.5)), ["A"])
-        handle = sim.register_observable_particle_positions(1, None, [])
+        sim.register_observable_n_particles(1, ["A"], lambda n: sim.add_particle("A", common.Vec(1.5, 2.5, 3.5)))
+        handle = sim.register_observable_particle_positions(1, [])
         n_timesteps = 19
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"particle_positions", int(3))
@@ -92,8 +92,8 @@ class TestObservablesIO(unittest.TestCase):
         sim.add_particle("A", common.Vec(0, 0, 0))
         sim.add_particle("B", common.Vec(0, 0, 0))
         # every time step, add one particle
-        sim.register_observable_n_particles(1, lambda n: sim.add_particle("A", common.Vec(1.5, 2.5, 3.5)), ["A"])
-        handle = sim.register_observable_particles(1, None)
+        sim.register_observable_n_particles(1, ["A"], lambda n: sim.add_particle("A", common.Vec(1.5, 2.5, 3.5)))
+        handle = sim.register_observable_particles(1)
         n_timesteps = 19
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"particles", int(3))
@@ -148,7 +148,7 @@ class TestObservablesIO(unittest.TestCase):
             callback_centers.append(pair[0])
             callback_rdf.append(pair[1])
 
-        handle = simulation.register_observable_radial_distribution(1, rdf_callback, bin_borders, ["A"], ["B"], density)
+        handle = simulation.register_observable_radial_distribution(1, bin_borders, ["A"], ["B"], density, rdf_callback)
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"radial_distribution", int(3))
             simulation.run(n_time_steps, 0.02)
@@ -182,7 +182,7 @@ class TestObservablesIO(unittest.TestCase):
         def com_callback(vec):
             callback_com.append(vec)
 
-        handle = simulation.register_observable_center_of_mass(1, com_callback, ["A", "B"])
+        handle = simulation.register_observable_center_of_mass(1, ["A", "B"], com_callback)
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"com", 3)
             simulation.run(n_time_steps, 0.02)
@@ -218,7 +218,7 @@ class TestObservablesIO(unittest.TestCase):
         def hist_callback(hist):
             callback_hist.append(hist)
 
-        handle = simulation.register_observable_histogram_along_axis(2, hist_callback, bin_borders, 0, ["A", "B"])
+        handle = simulation.register_observable_histogram_along_axis(2, bin_borders, 0, ["A", "B"], hist_callback)
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"hist_along_x_axis", int(3))
             simulation.run(n_time_steps, 0.02)
@@ -259,8 +259,8 @@ class TestObservablesIO(unittest.TestCase):
             simulation.add_particle("A", common.Vec(-1, -1, -1))
             simulation.add_particle("B", common.Vec(-1, -1, -1))
 
-        handle_a_b_particles = simulation.register_observable_n_particles(1, callback_ab, ["A", "B"])
-        handle_all = simulation.register_observable_n_particles(1, callback_all, [])
+        handle_a_b_particles = simulation.register_observable_n_particles(1, ["A", "B"], callback_ab)
+        handle_all = simulation.register_observable_n_particles(1, [], callback_all)
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle_a_b_particles.enable_write_to_file(f, u"n_a_b_particles", int(3))
             handle_all.enable_write_to_file(f, u"n_particles", int(5))
@@ -296,7 +296,7 @@ class TestObservablesIO(unittest.TestCase):
 
         n_timesteps = 1
 
-        handle = sim.register_observable_reactions(1, None)
+        handle = sim.register_observable_reactions(1)
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"reactions", int(3))
             sim.run(n_timesteps, 1)
@@ -342,7 +342,7 @@ class TestObservablesIO(unittest.TestCase):
         sim.add_particle("C", common.Vec(1.1, 1.0, 1.0))
 
         n_timesteps = 1
-        handle = sim.register_observable_reaction_counts(1, None)
+        handle = sim.register_observable_reaction_counts(1)
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"reactions", int(3))
             sim.run(n_timesteps, 1)
@@ -375,8 +375,8 @@ class TestObservablesIO(unittest.TestCase):
         sim.register_particle_type("A", .1, .1)
         sim.add_particle("A", common.Vec(0, 0, 0))
         # every time step, add one particle
-        sim.register_observable_n_particles(1, lambda n: sim.add_particle("A", common.Vec(1.5, 2.5, 3.5)), ["A"])
-        handle = sim.register_observable_forces(1, None, [])
+        sim.register_observable_n_particles(1, ["A"], lambda n: sim.add_particle("A", common.Vec(1.5, 2.5, 3.5)))
+        handle = sim.register_observable_forces(1, [])
         n_timesteps = 19
         with closing(io.File(fname, io.FileAction.CREATE, io.FileFlag.OVERWRITE)) as f:
             handle.enable_write_to_file(f, u"forces", int(3))

--- a/wrappers/python/src/python/readdy/tests/test_scheme_api.py
+++ b/wrappers/python/src/python/readdy/tests/test_scheme_api.py
@@ -81,7 +81,7 @@ class TestSchemeApi(unittest.TestCase):
         def increment(result):
             counter[0] += 1
 
-        sim.register_observable_n_particles(1, increment, ["A"])
+        sim.register_observable_n_particles(1, ["A"], increment)
         scheme = sim.run_scheme_readdy(True).configure(0.1)
         do_continue = lambda t: t < 5
         scheme.run_with_criterion(do_continue)
@@ -101,7 +101,7 @@ class TestSchemeApi(unittest.TestCase):
             if result[0] >= 8:
                 shall_stop[0] = True
 
-        sim.register_observable_n_particles(1, increment, ["A"])
+        sim.register_observable_n_particles(1, ["A"], increment)
         scheme = sim.run_scheme_readdy(True).configure(1.)
         do_continue = lambda t: not shall_stop[0]
         scheme.run_with_criterion(do_continue)

--- a/wrappers/python/src/python/readdy/tests/test_topologies.py
+++ b/wrappers/python/src/python/readdy/tests/test_topologies.py
@@ -59,7 +59,7 @@ class TestTopologies(unittest.TestCase):
         def callback(result):
             forces.append(result)
 
-        sim.register_observable_forces(1, callback, ["T"])
+        sim.register_observable_forces(1, ["T"], callback)
         sim.run_scheme_readdy(True).configure_and_run(1, 0)
         np.testing.assert_equal(len(forces), 1)
         np.testing.assert_equal(len(forces[0]), 4)


### PR DESCRIPTION
- fix potential memory leak in python binding
- setter for skin size (thanks @chrisfroe)
- replace `std::thread` with `std::async`
- added argument names to python binding shared lib
- observable callback is now a named parameter with default None, i.e., can be omitted