### PR TITLE
Identifiable reaction counts

### DIFF
--- a/include/readdy/common/Utils.h
+++ b/include/readdy/common/Utils.h
@@ -80,7 +80,7 @@ inline void for_each_value(const Collection& collection, Fun f)  {
 }
 
 template <typename map_t, typename value_t>
-inline void for_each_value_in_map(map_t &map, std::function<void(value_t)> &fun) {
+inline void for_each_value_in_map(map_t &map, const std::function<void(value_t&)> &fun) {
     for (auto&& entry : map) {
         fun(entry.second);
     }

--- a/include/readdy/common/Utils.h
+++ b/include/readdy/common/Utils.h
@@ -79,6 +79,13 @@ inline void for_each_value(const Collection& collection, Fun f)  {
     }
 }
 
+template <typename map_t, typename value_t>
+inline void for_each_value_in_map(map_t &map, std::function<void(value_t)> &fun) {
+    for (auto&& entry : map) {
+        fun(entry.second);
+    }
+}
+
 template<typename order_iterator, typename value_iterator>
 void reorder_destructive(order_iterator order_begin, order_iterator order_end, value_iterator v) {
     typedef typename std::iterator_traits<value_iterator>::value_type value_t;

--- a/include/readdy/io/DataSet.h
+++ b/include/readdy/io/DataSet.h
@@ -48,6 +48,11 @@ public:
 
     virtual ~DataSet();
 
+    DataSet(DataSet&& rhs) = default;
+    DataSet& operator=(DataSet&&) = delete;
+    DataSet(const DataSet&) = delete;
+    DataSet& operator=(const DataSet&) = delete;
+
     void close();
 
     template<bool no_vlen = !VLEN>

--- a/include/readdy/kernel/singlecpu/SCPUStateModel.h
+++ b/include/readdy/kernel/singlecpu/SCPUStateModel.h
@@ -45,6 +45,10 @@ namespace scpu {
 
 class SCPUStateModel : public readdy::model::KernelStateModel {
     using topology_action_factory = readdy::model::top::TopologyActionFactory;
+    using particle_t = readdy::model::Particle;
+    using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
+    using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
+            util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
 public:
 
     virtual void updateNeighborList() override;
@@ -90,9 +94,13 @@ public:
 
     const std::vector<readdy::model::reactions::ReactionRecord>& reactionRecords() const;
 
-    std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>& reactionCounts();
+    reaction_counts_order1_map &reactionCountsOrder1();
 
-    const std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>& reactionCounts() const;
+    const reaction_counts_order1_map &reactionCountsOrder1() const;
+
+    reaction_counts_order2_map &reactionCountsOrder2();
+
+    const reaction_counts_order2_map &reactionCountsOrder2() const;
 
     virtual void expected_n_particles(const std::size_t n) override;
 

--- a/include/readdy/kernel/singlecpu/SCPUStateModel.h
+++ b/include/readdy/kernel/singlecpu/SCPUStateModel.h
@@ -31,13 +31,14 @@
 
 #pragma once
 
-#include <readdy/model/KernelStateModel.h>
 #include <memory>
+#include <readdy/model/KernelStateModel.h>
 #include <readdy/model/Vec3.h>
 #include <readdy/kernel/singlecpu/model/SCPUParticleData.h>
 #include <readdy/model/KernelContext.h>
 #include <readdy/kernel/singlecpu/model/SCPUNeighborList.h>
 #include <readdy/model/reactions/ReactionRecord.h>
+#include <readdy/model/observables/ReactionCounts.h>
 
 namespace readdy {
 namespace kernel {
@@ -45,10 +46,8 @@ namespace scpu {
 
 class SCPUStateModel : public readdy::model::KernelStateModel {
     using topology_action_factory = readdy::model::top::TopologyActionFactory;
-    using particle_t = readdy::model::Particle;
-    using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
-    using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
-            util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
+    using reaction_counts_order1_map = readdy::model::observables::ReactionCounts::reaction_counts_order1_map;
+    using reaction_counts_order2_map = readdy::model::observables::ReactionCounts::reaction_counts_order2_map;
 public:
 
     virtual void updateNeighborList() override;
@@ -94,13 +93,9 @@ public:
 
     const std::vector<readdy::model::reactions::ReactionRecord>& reactionRecords() const;
 
-    reaction_counts_order1_map &reactionCountsOrder1();
+    const std::pair<reaction_counts_order1_map, reaction_counts_order2_map> &reactionCounts() const;
 
-    const reaction_counts_order1_map &reactionCountsOrder1() const;
-
-    reaction_counts_order2_map &reactionCountsOrder2();
-
-    const reaction_counts_order2_map &reactionCountsOrder2() const;
+    std::pair<reaction_counts_order1_map, reaction_counts_order2_map> &reactionCounts();
 
     virtual void expected_n_particles(const std::size_t n) override;
 

--- a/include/readdy/kernel/singlecpu/actions/SCPUReactionUtils.h
+++ b/include/readdy/kernel/singlecpu/actions/SCPUReactionUtils.h
@@ -120,6 +120,7 @@ void performReaction(
         }
     }
 }
+
 }
 }
 }

--- a/include/readdy/kernel/singlecpu/observables/SCPUObservables.h
+++ b/include/readdy/kernel/singlecpu/observables/SCPUObservables.h
@@ -240,13 +240,13 @@ public:
     virtual ~SCPUReactionCounts() = default;
 
     virtual void evaluate() override {
-        auto &order1 = std::get<0>(result);
-        auto &order2 = std::get<1>(result);
-        const auto& counts = kernel->getSCPUKernelStateModel().reactionCounts();
-        const auto& counts_order1 = std::get<0>(counts);
-        const auto& counts_order2 = std::get<1>(counts);
-        order1.assign(counts_order1.begin(), counts_order1.end());
-        order2.assign(counts_order2.begin(), counts_order2.end());
+        // the initialize is necessary if evaluate is called before the reaction counts have been recorded by the state-model/reaction-handler
+        // this becomes important not only when writing the result to file but also when other observables depend on this result
+        readdy::model::observables::util::initializeReactionCountMapping(std::get<0>(result), std::get<1>(result), kernel->getKernelContext());
+        auto &stateModel = kernel->getSCPUKernelStateModel();
+        const auto& countsOrder1 = stateModel.reactionCountsOrder1();
+        const auto& countsOrder2 = stateModel.reactionCountsOrder2();
+        readdy::model::observables::util::copyCountsFromStateToResult(countsOrder1, countsOrder2, std::get<0>(result), std::get<1>(result));
     }
 
 private:

--- a/include/readdy/kernel/singlecpu/observables/SCPUObservables.h
+++ b/include/readdy/kernel/singlecpu/observables/SCPUObservables.h
@@ -241,13 +241,7 @@ public:
 
     virtual void evaluate() override {
         readdy::model::observables::ReactionCounts::initializeCounts(result, kernel->getKernelContext());
-        auto &reactionCounts = kernel->getSCPUKernelStateModel().reactionCounts();
-        const auto& countsOrder1 = std::get<0>(reactionCounts);
-        const auto& countsOrder2 = std::get<1>(reactionCounts);
-        auto &resultOrder1 = std::get<0>(result);
-        auto &resultOrder2 = std::get<1>(result);
-        assignVectorsOfMap(countsOrder1, resultOrder1);
-        assignVectorsOfMap(countsOrder2, resultOrder2);
+        assignCountsToResult(kernel->getSCPUKernelStateModel().reactionCounts(), result);
     }
 
 private:

--- a/include/readdy/kernel/singlecpu/observables/SCPUObservables.h
+++ b/include/readdy/kernel/singlecpu/observables/SCPUObservables.h
@@ -240,13 +240,14 @@ public:
     virtual ~SCPUReactionCounts() = default;
 
     virtual void evaluate() override {
-        // the initialize is necessary if evaluate is called before the reaction counts have been recorded by the state-model/reaction-handler
-        // this becomes important not only when writing the result to file but also when other observables depend on this result
-        readdy::model::observables::util::initializeReactionCountMapping(std::get<0>(result), std::get<1>(result), kernel->getKernelContext());
-        auto &stateModel = kernel->getSCPUKernelStateModel();
-        const auto& countsOrder1 = stateModel.reactionCountsOrder1();
-        const auto& countsOrder2 = stateModel.reactionCountsOrder2();
-        readdy::model::observables::util::copyCountsFromStateToResult(countsOrder1, countsOrder2, std::get<0>(result), std::get<1>(result));
+        readdy::model::observables::ReactionCounts::initializeCounts(result, kernel->getKernelContext());
+        auto &reactionCounts = kernel->getSCPUKernelStateModel().reactionCounts();
+        const auto& countsOrder1 = std::get<0>(reactionCounts);
+        const auto& countsOrder2 = std::get<1>(reactionCounts);
+        auto &resultOrder1 = std::get<0>(result);
+        auto &resultOrder2 = std::get<1>(result);
+        assignVectorsOfMap(countsOrder1, resultOrder1);
+        assignVectorsOfMap(countsOrder2, resultOrder2);
     }
 
 private:

--- a/include/readdy/model/observables/ReactionCounts.h
+++ b/include/readdy/model/observables/ReactionCounts.h
@@ -42,17 +42,57 @@ NAMESPACE_BEGIN(model)
 NAMESPACE_BEGIN(observables)
 
 class ReactionCounts : public Observable<std::pair<
-        std::unordered_map<readdy::model::Particle::type_type, std::vector<std::size_t>>,
+        std::unordered_map<particle_type_type, std::vector<std::size_t>>,
         std::unordered_map<readdy::util::particle_type_pair, std::vector<std::size_t>, readdy::util::particle_type_pair_hasher, readdy::util::particle_type_pair_equal_to>
 >> {
 public:
-    using reaction_counts_order1_map = std::unordered_map<readdy::model::Particle::type_type, std::vector<std::size_t>>;
-    using reaction_counts_order2_map = std::unordered_map<readdy::util::particle_type_pair, std::vector<std::size_t>, readdy::util::particle_type_pair_hasher, readdy::util::particle_type_pair_equal_to>;
+    using reaction_counts_order1_map = typename std::tuple_element<0, result_t>::type;
+    using reaction_counts_order2_map = typename std::tuple_element<1, result_t>::type;
+
     ReactionCounts(Kernel *const kernel, unsigned int stride);
 
     virtual ~ReactionCounts();
 
     virtual void flush() override;
+
+    /*
+     * Initialize the maps corresponding to first and second order reaction counts. If they were not used before, that means creating key-value pairs in
+     * the maps and setting the values, which are vectors, to the correct size. If they were used before, all counts within the value-vectors will be
+     * filled with zeros. This is used for the reaction-counts object in the state-model as well as the result object of the corresponding observable.
+     */
+    static void
+    initializeCounts(std::pair<ReactionCounts::reaction_counts_order1_map, ReactionCounts::reaction_counts_order2_map> &reactionCounts,
+                     const readdy::model::KernelContext &ctx) {
+        auto &order1Counts = std::get<0>(reactionCounts);
+        auto &order2Counts = std::get<1>(reactionCounts);
+        for (const auto &entry1 : ctx.particle_types().type_mapping()) {
+            const auto &pType1 = entry1.second;
+            const auto numberReactionsOrder1 = ctx.reactions().order1_by_type(pType1).size();
+            if (numberReactionsOrder1 > 0) {
+                // will create an entry for pType1 if necessary
+                auto &countsForType = order1Counts[pType1];
+                if (countsForType.empty()) {
+                    countsForType.resize(numberReactionsOrder1);
+                } else {
+                    std::fill(countsForType.begin(), countsForType.end(), 0);
+                }
+            }
+            for (const auto &entry2: ctx.particle_types().type_mapping()) {
+                const auto &pType2 = entry2.second;
+                if (pType2 < pType1) continue;
+                const auto numberReactionsOrder2 = ctx.reactions().order2_by_type(pType1, pType2).size();
+                if (numberReactionsOrder2 > 0) {
+                    // will create an entry for particle-type-pair if necessary
+                    auto &countsForPair = order2Counts[std::tie(pType1, pType2)];
+                    if (countsForPair.empty()) {
+                        countsForPair.resize(numberReactionsOrder2);
+                    } else {
+                        std::fill(countsForPair.begin(), countsForPair.end(), 0);
+                    }
+                }
+            }
+        }
+    }
 
 protected:
     virtual void initialize(Kernel *const kernel) override;
@@ -61,83 +101,27 @@ protected:
 
     virtual void append() override;
 
-    struct Impl;
-    std::unique_ptr<Impl> pimpl;
-};
-
-NAMESPACE_BEGIN(util)
-
-/*
- * Initialize the maps corresponding to first and second order reaction counts. If they were not used before, that means creating key-value pairs in
- * the maps and setting the values, which are vectors, to the correct size. If they were used before, all counts within the value-vectors will be
- * filled with zeros. This is used for the reaction-counts object in the state-model as well as the result object of the corresponding observable.
- */
-inline void initializeReactionCountMapping(ReactionCounts::reaction_counts_order1_map &order1Counts,
-                                           ReactionCounts::reaction_counts_order2_map &order2Counts,
-                                           const readdy::model::KernelContext &ctx) {
-    for (const auto &entry1 : ctx.particle_types().type_mapping()) {
-        const auto& pType1 = entry1.second;
-        const auto numberReactionsOrder1 = ctx.reactions().order1_by_type(pType1).size();
-        if (numberReactionsOrder1 > 0) {
-            // will create an entry for pType1 if necessary
-            auto &countsForType = order1Counts[pType1];
-            if (countsForType.empty()) {
-                countsForType.resize(numberReactionsOrder1);
-            } else {
-                std::fill(countsForType.begin(), countsForType.end(), 0);
-            }
-        }
-        for (const auto &entry2: ctx.particle_types().type_mapping()) {
-            const auto &pType2 = entry2.second;
-            if (pType2 < pType1) continue;
-            const auto numberReactionsOrder2 = ctx.reactions().order2_by_type(pType1, pType2).size();
-            if (numberReactionsOrder2 > 0) {
-                readdy::util::particle_type_pair particleTypePair(pType1, pType2);
-                // will create an entry for particleTypePair if necessary
-                auto &countsForPair = order2Counts[particleTypePair];
-                if (countsForPair.empty()) {
-                    countsForPair.resize(numberReactionsOrder2);
-                } else {
-                    std::fill(countsForPair.begin(), countsForPair.end(), 0);
-                }
-            }
-        }
-    }
-}
-
-inline void copyCountsFromStateToResult(const ReactionCounts::reaction_counts_order1_map& countsOrder1From,
-                                        const ReactionCounts::reaction_counts_order2_map& countsOrder2From,
-                                        ReactionCounts::reaction_counts_order1_map & countsOrder1To,
-                                        ReactionCounts::reaction_counts_order2_map & countsOrder2To) {
-    // Do not just copy the whole map, only copy over parts, that actually exist in the state-model.
-    // This might be nothing, if the reaction-handler did not run yet. However the observable-result-maps
-    // should have the correct structure dictated by the initialize step.
-    for (const auto &entry : countsOrder1From) {
-        const auto &countsForType = entry.second;
-        if (!countsForType.empty()) {
-            countsOrder1To[entry.first] = countsForType;
-        }
-    }
-    for (const auto &entry : countsOrder2From) {
-        const auto &countsForPair = entry.second;
-        if (!countsForPair.empty()) {
-            countsOrder2To[entry.first] = countsForPair;
-        }
-    }
-}
-
-template <typename counts_map_t, typename dset_map_t>
-inline void writeCountsToDataSets(const counts_map_t &countsMap, dset_map_t &dsetMap) {
-    for (const auto &entry : countsMap) {
-        auto& dataSet = dsetMap.at(entry.first);
-        const auto &counts = entry.second;
-        if (dataSet) {
+    template<typename counts_map_t, typename dset_map_t>
+    void writeCountsToDataSets(const counts_map_t &countsMap, dset_map_t &dsetMap) {
+        for (const auto &entry : countsMap) {
+            auto &dataSet = dsetMap.at(entry.first);
+            const auto &counts = entry.second;
             dataSet->append({1, counts.size()}, counts.data());
         }
     }
-}
 
-NAMESPACE_END(util)
+    template<typename counts_map_t>
+    void assignVectorsOfMap(const counts_map_t &from, counts_map_t &to) {
+        for (const auto &entry: from) {
+            const auto &fromVector = entry.second;
+            auto &toVector = to.at(entry.first);
+            toVector.assign(fromVector.begin(), fromVector.end());
+        }
+    }
+
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+};
 
 NAMESPACE_END(observables)
 NAMESPACE_END(model)

--- a/include/readdy/model/observables/ReactionCounts.h
+++ b/include/readdy/model/observables/ReactionCounts.h
@@ -62,37 +62,7 @@ public:
      */
     static void
     initializeCounts(std::pair<ReactionCounts::reaction_counts_order1_map, ReactionCounts::reaction_counts_order2_map> &reactionCounts,
-                     const readdy::model::KernelContext &ctx) {
-        auto &order1Counts = std::get<0>(reactionCounts);
-        auto &order2Counts = std::get<1>(reactionCounts);
-        for (const auto &entry1 : ctx.particle_types().type_mapping()) {
-            const auto &pType1 = entry1.second;
-            const auto numberReactionsOrder1 = ctx.reactions().order1_by_type(pType1).size();
-            if (numberReactionsOrder1 > 0) {
-                // will create an entry for pType1 if necessary
-                auto &countsForType = order1Counts[pType1];
-                if (countsForType.empty()) {
-                    countsForType.resize(numberReactionsOrder1);
-                } else {
-                    std::fill(countsForType.begin(), countsForType.end(), 0);
-                }
-            }
-            for (const auto &entry2: ctx.particle_types().type_mapping()) {
-                const auto &pType2 = entry2.second;
-                if (pType2 < pType1) continue;
-                const auto numberReactionsOrder2 = ctx.reactions().order2_by_type(pType1, pType2).size();
-                if (numberReactionsOrder2 > 0) {
-                    // will create an entry for particle-type-pair if necessary
-                    auto &countsForPair = order2Counts[std::tie(pType1, pType2)];
-                    if (countsForPair.empty()) {
-                        countsForPair.resize(numberReactionsOrder2);
-                    } else {
-                        std::fill(countsForPair.begin(), countsForPair.end(), 0);
-                    }
-                }
-            }
-        }
-    }
+                     const readdy::model::KernelContext &ctx);
 
 protected:
     virtual void initialize(Kernel *const kernel) override;
@@ -101,23 +71,7 @@ protected:
 
     virtual void append() override;
 
-    template<typename counts_map_t, typename dset_map_t>
-    void writeCountsToDataSets(const counts_map_t &countsMap, dset_map_t &dsetMap) {
-        for (const auto &entry : countsMap) {
-            auto &dataSet = dsetMap.at(entry.first);
-            const auto &counts = entry.second;
-            dataSet.append({1, counts.size()}, counts.data());
-        }
-    }
-
-    template<typename counts_map_t>
-    void assignVectorsOfMap(const counts_map_t &from, counts_map_t &to) {
-        for (const auto &entry: from) {
-            const auto &fromVector = entry.second;
-            auto &toVector = to.at(entry.first);
-            toVector.assign(fromVector.begin(), fromVector.end());
-        }
-    }
+    void assignCountsToResult(const result_t &from, result_t &to);
 
     struct Impl;
     std::unique_ptr<Impl> pimpl;

--- a/include/readdy/model/observables/ReactionCounts.h
+++ b/include/readdy/model/observables/ReactionCounts.h
@@ -33,13 +33,21 @@
 #pragma once
 
 #include "Observable.h"
+#include <readdy/common/ParticleTypeTuple.h>
+#include <readdy/model/Particle.h>
+#include <readdy/model/KernelContext.h>
 
 NAMESPACE_BEGIN(readdy)
 NAMESPACE_BEGIN(model)
 NAMESPACE_BEGIN(observables)
 
-class ReactionCounts : public Observable<std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>> {
+class ReactionCounts : public Observable<std::pair<
+        std::unordered_map<readdy::model::Particle::type_type, std::vector<std::size_t>>,
+        std::unordered_map<readdy::util::particle_type_pair, std::vector<std::size_t>, readdy::util::particle_type_pair_hasher, readdy::util::particle_type_pair_equal_to>
+>> {
 public:
+    using reaction_counts_order1_map = std::unordered_map<readdy::model::Particle::type_type, std::vector<std::size_t>>;
+    using reaction_counts_order2_map = std::unordered_map<readdy::util::particle_type_pair, std::vector<std::size_t>, readdy::util::particle_type_pair_hasher, readdy::util::particle_type_pair_equal_to>;
     ReactionCounts(Kernel *const kernel, unsigned int stride);
 
     virtual ~ReactionCounts();
@@ -57,6 +65,79 @@ protected:
     std::unique_ptr<Impl> pimpl;
 };
 
+NAMESPACE_BEGIN(util)
+
+/*
+ * Initialize the maps corresponding to first and second order reaction counts. If they were not used before, that means creating key-value pairs in
+ * the maps and setting the values, which are vectors, to the correct size. If they were used before, all counts within the value-vectors will be
+ * filled with zeros. This is used for the reaction-counts object in the state-model as well as the result object of the corresponding observable.
+ */
+inline void initializeReactionCountMapping(ReactionCounts::reaction_counts_order1_map &order1Counts,
+                                           ReactionCounts::reaction_counts_order2_map &order2Counts,
+                                           const readdy::model::KernelContext &ctx) {
+    for (const auto &entry1 : ctx.particle_types().type_mapping()) {
+        const auto& pType1 = entry1.second;
+        const auto numberReactionsOrder1 = ctx.reactions().order1_by_type(pType1).size();
+        if (numberReactionsOrder1 > 0) {
+            // will create an entry for pType1 if necessary
+            auto &countsForType = order1Counts[pType1];
+            if (countsForType.empty()) {
+                countsForType.resize(numberReactionsOrder1);
+            } else {
+                std::fill(countsForType.begin(), countsForType.end(), 0);
+            }
+        }
+        for (const auto &entry2: ctx.particle_types().type_mapping()) {
+            const auto &pType2 = entry2.second;
+            if (pType2 < pType1) continue;
+            const auto numberReactionsOrder2 = ctx.reactions().order2_by_type(pType1, pType2).size();
+            if (numberReactionsOrder2 > 0) {
+                readdy::util::particle_type_pair particleTypePair(pType1, pType2);
+                // will create an entry for particleTypePair if necessary
+                auto &countsForPair = order2Counts[particleTypePair];
+                if (countsForPair.empty()) {
+                    countsForPair.resize(numberReactionsOrder2);
+                } else {
+                    std::fill(countsForPair.begin(), countsForPair.end(), 0);
+                }
+            }
+        }
+    }
+}
+
+inline void copyCountsFromStateToResult(const ReactionCounts::reaction_counts_order1_map& countsOrder1From,
+                                        const ReactionCounts::reaction_counts_order2_map& countsOrder2From,
+                                        ReactionCounts::reaction_counts_order1_map & countsOrder1To,
+                                        ReactionCounts::reaction_counts_order2_map & countsOrder2To) {
+    // Do not just copy the whole map, only copy over parts, that actually exist in the state-model.
+    // This might be nothing, if the reaction-handler did not run yet. However the observable-result-maps
+    // should have the correct structure dictated by the initialize step.
+    for (const auto &entry : countsOrder1From) {
+        const auto &countsForType = entry.second;
+        if (!countsForType.empty()) {
+            countsOrder1To[entry.first] = countsForType;
+        }
+    }
+    for (const auto &entry : countsOrder2From) {
+        const auto &countsForPair = entry.second;
+        if (!countsForPair.empty()) {
+            countsOrder2To[entry.first] = countsForPair;
+        }
+    }
+}
+
+template <typename counts_map_t, typename dset_map_t>
+inline void writeCountsToDataSets(const counts_map_t &countsMap, dset_map_t &dsetMap) {
+    for (const auto &entry : countsMap) {
+        auto& dataSet = dsetMap.at(entry.first);
+        const auto &counts = entry.second;
+        if (dataSet) {
+            dataSet->append({1, counts.size()}, counts.data());
+        }
+    }
+}
+
+NAMESPACE_END(util)
 
 NAMESPACE_END(observables)
 NAMESPACE_END(model)

--- a/include/readdy/model/observables/ReactionCounts.h
+++ b/include/readdy/model/observables/ReactionCounts.h
@@ -106,7 +106,7 @@ protected:
         for (const auto &entry : countsMap) {
             auto &dataSet = dsetMap.at(entry.first);
             const auto &counts = entry.second;
-            dataSet->append({1, counts.size()}, counts.data());
+            dataSet.append({1, counts.size()}, counts.data());
         }
     }
 

--- a/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
@@ -39,6 +39,7 @@
 #include <readdy/kernel/cpu/model/CPUParticleData.h>
 #include <readdy/model/reactions/ReactionRecord.h>
 #include <readdy/common/thread/scoped_async.h>
+#include <readdy/model/observables/ReactionCounts.h>
 
 namespace readdy {
 namespace kernel {
@@ -49,9 +50,8 @@ public:
 
     using data_t = readdy::kernel::cpu::model::CPUParticleData;
     using particle_t = readdy::model::Particle;
-    using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
-    using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
-            util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
+    using reaction_counts_order1_map = readdy::model::observables::ReactionCounts::reaction_counts_order1_map;
+    using reaction_counts_order2_map = readdy::model::observables::ReactionCounts::reaction_counts_order2_map;
 
     CPUStateModel(readdy::model::KernelContext *const context, readdy::util::thread::Config const *const config,
                   readdy::model::top::TopologyActionFactory const *const taf);
@@ -95,13 +95,9 @@ public:
 
     const std::vector<readdy::model::reactions::ReactionRecord> &reactionRecords() const;
 
-    reaction_counts_order1_map &reactionCountsOrder1();
+    const std::pair<reaction_counts_order1_map, reaction_counts_order2_map> &reactionCounts() const;
 
-    const reaction_counts_order1_map &reactionCountsOrder1() const;
-
-    reaction_counts_order2_map &reactionCountsOrder2();
-
-    const reaction_counts_order2_map &reactionCountsOrder2() const;
+    std::pair<reaction_counts_order1_map, reaction_counts_order2_map> &reactionCounts();
 
     virtual particle_t getParticleForIndex(const std::size_t index) const override;
 

--- a/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/CPUStateModel.h
@@ -48,6 +48,10 @@ class CPUStateModel : public readdy::model::KernelStateModel {
 public:
 
     using data_t = readdy::kernel::cpu::model::CPUParticleData;
+    using particle_t = readdy::model::Particle;
+    using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
+    using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
+            util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
 
     CPUStateModel(readdy::model::KernelContext *const context, readdy::util::thread::Config const *const config,
                   readdy::model::top::TopologyActionFactory const *const taf);
@@ -56,17 +60,17 @@ public:
 
     virtual const std::vector<readdy::model::Vec3> getParticlePositions() const override;
 
-    virtual const std::vector<readdy::model::Particle> getParticles() const override;
+    virtual const std::vector<particle_t> getParticles() const override;
 
     virtual void updateNeighborList() override;
 
     virtual void calculateForces() override;
 
-    virtual void addParticle(const readdy::model::Particle &p) override;
+    virtual void addParticle(const particle_t &p) override;
 
-    virtual void addParticles(const std::vector<readdy::model::Particle> &p) override;
+    virtual void addParticles(const std::vector<particle_t> &p) override;
 
-    virtual void removeParticle(const readdy::model::Particle &p) override;
+    virtual void removeParticle(const particle_t &p) override;
 
     virtual void removeAllParticles() override;
 
@@ -91,11 +95,15 @@ public:
 
     const std::vector<readdy::model::reactions::ReactionRecord> &reactionRecords() const;
 
-    std::tuple<std::vector<std::size_t>, std::vector<std::size_t>> &reactionCounts();
+    reaction_counts_order1_map &reactionCountsOrder1();
 
-    const std::tuple<std::vector<std::size_t>, std::vector<std::size_t>> &reactionCounts() const;
+    const reaction_counts_order1_map &reactionCountsOrder1() const;
 
-    virtual readdy::model::Particle getParticleForIndex(const std::size_t index) const override;
+    reaction_counts_order2_map &reactionCountsOrder2();
+
+    const reaction_counts_order2_map &reactionCountsOrder2() const;
+
+    virtual particle_t getParticleForIndex(const std::size_t index) const override;
 
 private:
     struct Impl;

--- a/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
@@ -49,11 +49,9 @@ using reaction_type = readdy::model::reactions::ReactionType;
 using nl_t = readdy::kernel::cpu::model::CPUNeighborList;
 using ctx_t = std::remove_const<decltype(std::declval<kernel_t>().getKernelContext())>::type;
 using event_t = Event;
-using particle_t = readdy::model::Particle;
 using record_t = readdy::model::reactions::ReactionRecord;
-using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
-using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
-        util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
+using reaction_counts_order1_map = readdy::model::observables::ReactionCounts::reaction_counts_order1_map;
+using reaction_counts_order2_map = readdy::model::observables::ReactionCounts::reaction_counts_order2_map;
 using reaction_counts_t = std::pair<reaction_counts_order1_map, reaction_counts_order2_map>;
 
 template<bool approximated>
@@ -73,8 +71,7 @@ inline bool shouldPerformEvent(const double rate, const double timestep, bool ap
 data_t::update_t handleEventsGillespie(
         CPUKernel *const kernel, double timeStep,
         bool filterEventsInAdvance, bool approximateRate,
-        std::vector<event_t> &&events, std::vector<record_t> *maybeRecords, reaction_counts_order1_map *maybeCountsOrder1,
-        reaction_counts_order2_map *maybeCountsOrder2);
+        std::vector<event_t> &&events, std::vector<record_t> *maybeRecords, reaction_counts_t *maybeCounts);
 
 template<typename ParticleIndexCollection>
 void gatherEvents(CPUKernel *const kernel, const ParticleIndexCollection &particles, const nl_t* nl,

--- a/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
@@ -51,7 +51,10 @@ using ctx_t = std::remove_const<decltype(std::declval<kernel_t>().getKernelConte
 using event_t = Event;
 using particle_t = readdy::model::Particle;
 using record_t = readdy::model::reactions::ReactionRecord;
-using reaction_counts_t = std::tuple<std::vector<std::size_t>, std::vector<std::size_t>>;
+using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
+using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
+        util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
+using reaction_counts_t = std::pair<reaction_counts_order1_map, reaction_counts_order2_map>;
 
 template<bool approximated>
 bool performReactionEvent(const double rate, const double timeStep) {
@@ -70,7 +73,8 @@ inline bool shouldPerformEvent(const double rate, const double timestep, bool ap
 data_t::update_t handleEventsGillespie(
         CPUKernel *const kernel, double timeStep,
         bool filterEventsInAdvance, bool approximateRate,
-        std::vector<event_t> &&events, std::vector<record_t>* maybeRecords, reaction_counts_t* maybeCounts);
+        std::vector<event_t> &&events, std::vector<record_t> *maybeRecords, reaction_counts_order1_map *maybeCountsOrder1,
+        reaction_counts_order2_map *maybeCountsOrder2);
 
 template<typename ParticleIndexCollection>
 void gatherEvents(CPUKernel *const kernel, const ParticleIndexCollection &particles, const nl_t* nl,

--- a/kernels/cpu/src/CPUStateModel.cpp
+++ b/kernels/cpu/src/CPUStateModel.cpp
@@ -120,10 +120,8 @@ void calculateForcesThread(entries_it begin, entries_it end, neighbors_it neighb
 }
 
 struct CPUStateModel::Impl {
-    using particle_t = readdy::model::Particle;
-    using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
-    using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
-            util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
+    using reaction_counts_order1_map = CPUStateModel::reaction_counts_order1_map;
+    using reaction_counts_order2_map = CPUStateModel::reaction_counts_order2_map;
     readdy::model::KernelContext *context;
     std::unique_ptr<readdy::kernel::cpu::model::CPUNeighborList> neighborList;
     double currentEnergy = 0;
@@ -131,8 +129,7 @@ struct CPUStateModel::Impl {
     std::vector<std::unique_ptr<readdy::model::top::GraphTopology>> topologies{};
     top_action_factory const *const topologyActionFactory;
     std::vector<readdy::model::reactions::ReactionRecord> reactionRecords{};
-    reaction_counts_order1_map reactionCountsOrder1 {};
-    reaction_counts_order2_map reactionCountsOrder2 {};
+    std::pair<reaction_counts_order1_map, reaction_counts_order2_map> reactionCounts;
 
     template<bool fixpos = true>
     const model::CPUParticleData &cdata() const {
@@ -320,22 +317,6 @@ const std::vector<readdy::model::reactions::ReactionRecord> &CPUStateModel::reac
     return pimpl->reactionRecords;
 }
 
-CPUStateModel::reaction_counts_order1_map &CPUStateModel::reactionCountsOrder1() {
-    return pimpl->reactionCountsOrder1;
-}
-
-const CPUStateModel::reaction_counts_order1_map &CPUStateModel::reactionCountsOrder1() const {
-    return pimpl->reactionCountsOrder1;
-}
-
-CPUStateModel::reaction_counts_order2_map &CPUStateModel::reactionCountsOrder2() {
-    return pimpl->reactionCountsOrder2;
-}
-
-const CPUStateModel::reaction_counts_order2_map &CPUStateModel::reactionCountsOrder2() const {
-    return pimpl->reactionCountsOrder2;
-}
-
 readdy::model::Particle CPUStateModel::getParticleForIndex(const std::size_t index) const {
     return pimpl->cdata<false>().getParticle(index);
 }
@@ -345,6 +326,14 @@ void CPUStateModel::expected_n_particles(const std::size_t n) {
     if(data.size() < n) {
         data.reserve(n);
     }
+}
+
+const std::pair<CPUStateModel::reaction_counts_order1_map, CPUStateModel::reaction_counts_order2_map> &CPUStateModel::reactionCounts() const {
+    return pimpl->reactionCounts;
+}
+
+std::pair<CPUStateModel::reaction_counts_order1_map, CPUStateModel::reaction_counts_order2_map> &CPUStateModel::reactionCounts() {
+    return pimpl->reactionCounts;
 }
 
 CPUStateModel::~CPUStateModel() = default;

--- a/kernels/cpu/src/CPUStateModel.cpp
+++ b/kernels/cpu/src/CPUStateModel.cpp
@@ -120,6 +120,10 @@ void calculateForcesThread(entries_it begin, entries_it end, neighbors_it neighb
 }
 
 struct CPUStateModel::Impl {
+    using particle_t = readdy::model::Particle;
+    using reaction_counts_order1_map = std::unordered_map<particle_t::type_type, std::vector<std::size_t>>;
+    using reaction_counts_order2_map = std::unordered_map<util::particle_type_pair, std::vector<std::size_t>,
+            util::particle_type_pair_hasher, util::particle_type_pair_equal_to>;
     readdy::model::KernelContext *context;
     std::unique_ptr<readdy::kernel::cpu::model::CPUNeighborList> neighborList;
     double currentEnergy = 0;
@@ -127,7 +131,8 @@ struct CPUStateModel::Impl {
     std::vector<std::unique_ptr<readdy::model::top::GraphTopology>> topologies{};
     top_action_factory const *const topologyActionFactory;
     std::vector<readdy::model::reactions::ReactionRecord> reactionRecords{};
-    std::tuple<std::vector<std::size_t>, std::vector<std::size_t>> reactionCounts{};
+    reaction_counts_order1_map reactionCountsOrder1 {};
+    reaction_counts_order2_map reactionCountsOrder2 {};
 
     template<bool fixpos = true>
     const model::CPUParticleData &cdata() const {
@@ -315,12 +320,20 @@ const std::vector<readdy::model::reactions::ReactionRecord> &CPUStateModel::reac
     return pimpl->reactionRecords;
 }
 
-std::tuple<std::vector<std::size_t>, std::vector<std::size_t>> &CPUStateModel::reactionCounts() {
-    return pimpl->reactionCounts;
+CPUStateModel::reaction_counts_order1_map &CPUStateModel::reactionCountsOrder1() {
+    return pimpl->reactionCountsOrder1;
 }
 
-const std::tuple<std::vector<std::size_t>, std::vector<std::size_t>> &CPUStateModel::reactionCounts() const {
-    return pimpl->reactionCounts;
+const CPUStateModel::reaction_counts_order1_map &CPUStateModel::reactionCountsOrder1() const {
+    return pimpl->reactionCountsOrder1;
+}
+
+CPUStateModel::reaction_counts_order2_map &CPUStateModel::reactionCountsOrder2() {
+    return pimpl->reactionCountsOrder2;
+}
+
+const CPUStateModel::reaction_counts_order2_map &CPUStateModel::reactionCountsOrder2() const {
+    return pimpl->reactionCountsOrder2;
 }
 
 readdy::model::Particle CPUStateModel::getParticleForIndex(const std::size_t index) const {

--- a/kernels/cpu/src/actions/reactions/CPUGillespie.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUGillespie.cpp
@@ -48,9 +48,7 @@ void CPUGillespie::perform() {
     const auto nl = stateModel.getNeighborList();
 
     if(ctx.recordReactionCounts()) {
-        auto &countsOrder1 = stateModel.reactionCountsOrder1();
-        auto &countsOrder2 = stateModel.reactionCountsOrder2();
-        readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
+        readdy::model::observables::ReactionCounts::initializeCounts(stateModel.reactionCounts(), ctx);
     }
 
     double alpha = 0.0;
@@ -59,22 +57,20 @@ void CPUGillespie::perform() {
     if(ctx.recordReactionsWithPositions()) {
         stateModel.reactionRecords().clear();
         if(ctx.recordReactionCounts()) {
-            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), &stateModel.reactionRecords(),
-                                                         &stateModel.reactionCountsOrder1(), &stateModel.reactionCountsOrder2());
+            auto &counts = stateModel.reactionCounts();
+            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), &stateModel.reactionRecords(), &counts);
             nl->updateData(std::move(particlesUpdate));
         } else {
-            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), &stateModel.reactionRecords(),
-                                                         nullptr, nullptr);
+            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), &stateModel.reactionRecords(), nullptr);
             nl->updateData(std::move(particlesUpdate));
         }
     } else {
         if(ctx.recordReactionCounts()) {
-            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), nullptr,
-                                                         &stateModel.reactionCountsOrder1(), &stateModel.reactionCountsOrder2());
+            auto &counts = stateModel.reactionCounts();
+            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), nullptr, &counts);
             nl->updateData(std::move(particlesUpdate));
         } else {
-            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), nullptr,
-                                                         nullptr, nullptr);
+            auto particlesUpdate = handleEventsGillespie(kernel, timeStep, false, true, std::move(events), nullptr, nullptr);
             nl->updateData(std::move(particlesUpdate));
         }
     }

--- a/kernels/cpu/src/actions/reactions/CPUGillespieParallel.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUGillespieParallel.cpp
@@ -79,17 +79,13 @@ bool CPUGillespieParallel::SlicedBox::isInBox(const vec_t &particle) const {
 }
 
 void CPUGillespieParallel::perform() {
-    if (kernel->getKernelContext().recordReactionCounts()) {
-        auto &order1 = std::get<0>(kernel->getCPUKernelStateModel().reactionCounts());
-        auto &order2 = std::get<1>(kernel->getCPUKernelStateModel().reactionCounts());
-        if (order1.empty() && order2.empty()) {
-            const auto n_reactions_order1 = kernel->getKernelContext().reactions().n_order1();
-            const auto n_reactions_order2 = kernel->getKernelContext().reactions().n_order2();
-            order1.resize(n_reactions_order1);
-            order2.resize(n_reactions_order2);
-        } else {
-            std::fill(order1.begin(), order1.end(), 0);
-            std::fill(order2.begin(), order2.end(), 0);
+    {
+        const auto &ctx = kernel->getKernelContext();
+        if (ctx.recordReactionCounts()) {
+            auto &stateModel = kernel->getCPUKernelStateModel();
+            auto &countsOrder1 = stateModel.reactionCountsOrder1();
+            auto &countsOrder2 = stateModel.reactionCountsOrder2();
+            readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
         }
     }
 
@@ -223,25 +219,26 @@ void CPUGillespieParallel::handleBoxReactions() {
             // handle events
             {
                 reaction_counts_t local_counts{};
-                reaction_counts_t *local_counts_ptr = nullptr;
+                reaction_counts_order1_map *local_counts_o1_ptr = nullptr;
+                reaction_counts_order2_map *local_counts_o2_ptr = nullptr;
                 if (ctx.recordReactionCounts()) {
-                    const auto n_reactions_order1 = kernel->getKernelContext().reactions().n_order1();
-                    const auto n_reactions_order2 = kernel->getKernelContext().reactions().n_order2();
-                    std::get<0>(local_counts).resize(n_reactions_order1);
-                    std::get<1>(local_counts).resize(n_reactions_order2);
-                    local_counts_ptr = &local_counts;
+                    auto &countsOrder1 = std::get<0>(local_counts);
+                    auto &countsOrder2 = std::get<1>(local_counts);
+                    readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
+                    local_counts_o1_ptr = &std::get<0>(local_counts);
+                    local_counts_o2_ptr = &std::get<1>(local_counts);
                 }
                 if (ctx.recordReactionsWithPositions()) {
                     std::vector<record_t> records;
                     auto result = handleEventsGillespie(kernel, timeStep, false, approximateRate,
                                                         std::move(localEvents),
-                                                        &records, local_counts_ptr);
+                                                        &records, local_counts_o1_ptr, local_counts_o2_ptr);
                     newParticles.set_value(std::move(result));
                     promiseRecords.set_value(std::move(records));
                 } else {
                     auto result = handleEventsGillespie(kernel, timeStep, false, approximateRate,
                                                         std::move(localEvents),
-                                                        nullptr, local_counts_ptr);
+                                                        nullptr, local_counts_o1_ptr,local_counts_o2_ptr);
                     newParticles.set_value(std::move(result));
                     std::vector<record_t> no_records;
                     promiseRecords.set_value(std::move(no_records));
@@ -279,9 +276,10 @@ void CPUGillespieParallel::handleBoxReactions() {
     std::vector<std::vector<record_t>> attainedRecords;
     attainedRecords.reserve(records.size() + 1);
     {
+        const auto &ctx = kernel->getKernelContext();
         //readdy::util::Timer t ("\t fix marked");
         auto &data = *stateModel.getParticleData();
-        const auto &d2 = kernel->getKernelContext().getDistSquaredFun();
+        const auto &d2 = ctx.getDistSquaredFun();
         auto neighbor_list = stateModel.getNeighborList();
         std::vector<event_t> evilEvents{};
         double alpha = 0;
@@ -291,12 +289,17 @@ void CPUGillespieParallel::handleBoxReactions() {
             n_local_problematic += local_problematic.size();
             gatherEvents(kernel, std::move(local_problematic), neighbor_list, data, alpha, evilEvents, d2);
         }
-        auto count_ptr = kernel->getKernelContext().recordReactionCounts() ? &stateModel.reactionCounts() : nullptr;
-        if (kernel->getKernelContext().recordReactionsWithPositions()) {
+        auto count_o1_ptr = &stateModel.reactionCountsOrder1();
+        auto count_o2_ptr = &stateModel.reactionCountsOrder2();
+        if (!ctx.recordReactionCounts()) {
+            count_o1_ptr = nullptr;
+            count_o2_ptr = nullptr;
+        }
+        if (ctx.recordReactionsWithPositions()) {
             std::vector<record_t> newRecords;
             auto newProblemParticles = handleEventsGillespie(kernel, timeStep, false, approximateRate,
-                                                             std::move(evilEvents), &newRecords, count_ptr);
-            const auto &fixPos = kernel->getKernelContext().getFixPositionFun();
+                                                             std::move(evilEvents), &newRecords, count_o1_ptr, count_o2_ptr);
+            const auto &fixPos = ctx.getFixPositionFun();
             for (auto &&future : newParticles) {
                 neighbor_list->updateData(std::move(future.get()));
             }
@@ -315,8 +318,8 @@ void CPUGillespieParallel::handleBoxReactions() {
             }
         } else {
             auto newProblemParticles = handleEventsGillespie(kernel, timeStep, false, approximateRate,
-                                                             std::move(evilEvents), nullptr, count_ptr);
-            const auto &fixPos = kernel->getKernelContext().getFixPositionFun();
+                                                             std::move(evilEvents), nullptr, count_o1_ptr, count_o2_ptr);
+            const auto &fixPos = ctx.getFixPositionFun();
             for (auto &&future : newParticles) {
                 neighbor_list->updateData(std::move(future.get()));
             }
@@ -324,18 +327,25 @@ void CPUGillespieParallel::handleBoxReactions() {
         }
         {
             // update counts
-            auto &modelCounts = stateModel.reactionCounts();
-            auto &o1 = std::get<0>(modelCounts);
-            auto &o2 = std::get<1>(modelCounts);
+            auto &modelCountsOrder1 = stateModel.reactionCountsOrder1();
+            auto &modelCountsOrder2 = stateModel.reactionCountsOrder2();
             for (auto &&future : counts) {
                 auto c = std::move(future.get());
-                std::transform(o1.begin(), o1.end(), std::get<0>(c).begin(), o1.begin(), std::plus<std::size_t>());
-                std::transform(o2.begin(), o2.end(), std::get<1>(c).begin(), o2.begin(), std::plus<std::size_t>());
+                const auto &countsOrder1 = std::get<0>(c);
+                const auto &countsOrder2 = std::get<1>(c);
+                for (const auto &entry : countsOrder1) {
+                    auto &correspondingModelValue = modelCountsOrder1.at(entry.first);
+                    std::transform(correspondingModelValue.begin(), correspondingModelValue.end(), entry.second.begin(),
+                                   correspondingModelValue.begin(), std::plus<std::size_t>());
+                }
+                for (const auto &entry : countsOrder2) {
+                    auto &correspondingModelValue = modelCountsOrder2.at(entry.first);
+                    std::transform(correspondingModelValue.begin(), correspondingModelValue.end(), entry.second.begin(),
+                                   correspondingModelValue.begin(), std::plus<std::size_t>());
+                }
             }
         }
-
     }
-
 }
 
 void CPUGillespieParallel::findProblematicParticles(

--- a/kernels/cpu/src/actions/reactions/CPUUncontrolledApproximation.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUUncontrolledApproximation.cpp
@@ -125,9 +125,7 @@ void CPUUncontrolledApproximation::perform() {
         kernel->getCPUKernelStateModel().reactionRecords().clear();
     }
     if(ctx.recordReactionCounts()) {
-        auto &countsOrder1 = stateModel.reactionCountsOrder1();
-        auto &countsOrder2 = stateModel.reactionCountsOrder2();
-        readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
+        readdy::model::observables::ReactionCounts::initializeCounts(stateModel.reactionCounts(), ctx);
     }
 
     // gather events
@@ -203,7 +201,8 @@ void CPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        stateModel.reactionCountsOrder1().at(event.t1).at(event.reactionIdx)++;
+                        auto& countsOrder1 = std::get<0>(stateModel.reactionCounts());
+                        countsOrder1.at(event.t1).at(event.reactionIdx)++;
                     }
                     for(auto _it2 = it+1; _it2 != events.end(); ++_it2) {
                         if(_it2->idx1 == entry1 || _it2->idx2 == entry1) {
@@ -222,7 +221,8 @@ void CPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        stateModel.reactionCountsOrder2().at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
+                        auto& countsOrder2 = std::get<1>(stateModel.reactionCounts());
+                        countsOrder2.at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                     }
                     for(auto _it2 = it+1; _it2 != events.end(); ++_it2) {
                         if(_it2->idx1 == entry1 || _it2->idx2 == entry1 ||

--- a/kernels/cpu/src/actions/reactions/CPUUncontrolledApproximation.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUUncontrolledApproximation.cpp
@@ -117,24 +117,17 @@ void findEvents(data_iter_t begin, data_iter_t end, neighbor_list_iter_t nl_begi
 void CPUUncontrolledApproximation::perform() {
     const auto &ctx = kernel->getKernelContext();
     const auto &fixPos = ctx.getFixPositionFun();
-    auto &data = *kernel->getCPUKernelStateModel().getParticleData();
+    auto &stateModel = kernel->getCPUKernelStateModel();
+    auto &data = *stateModel.getParticleData();
     auto &nl = *kernel->getCPUKernelStateModel().getNeighborList();
 
     if(ctx.recordReactionsWithPositions()) {
         kernel->getCPUKernelStateModel().reactionRecords().clear();
     }
     if(ctx.recordReactionCounts()) {
-        auto& order1 = std::get<0>(kernel->getCPUKernelStateModel().reactionCounts());
-        auto& order2 = std::get<1>(kernel->getCPUKernelStateModel().reactionCounts());
-        if(order1.empty() && order2.empty()) {
-            const auto n_reactions_order1 = kernel->getKernelContext().reactions().n_order1();
-            const auto n_reactions_order2 = kernel->getKernelContext().reactions().n_order2();
-            order1.resize(n_reactions_order1);
-            order2.resize(n_reactions_order2);
-        } else {
-            std::fill(order1.begin(), order1.end(), 0);
-            std::fill(order2.begin(), order2.end(), 0);
-        }
+        auto &countsOrder1 = stateModel.reactionCountsOrder1();
+        auto &countsOrder2 = stateModel.reactionCountsOrder2();
+        readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
     }
 
     // gather events
@@ -210,7 +203,7 @@ void CPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        std::get<0>(kernel->getCPUKernelStateModel().reactionCounts()).at(event.reactionIdx)++;
+                        stateModel.reactionCountsOrder1().at(event.t1).at(event.reactionIdx)++;
                     }
                     for(auto _it2 = it+1; _it2 != events.end(); ++_it2) {
                         if(_it2->idx1 == entry1 || _it2->idx2 == entry1) {
@@ -229,7 +222,7 @@ void CPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        std::get<1>(kernel->getCPUKernelStateModel().reactionCounts()).at(event.reactionIdx)++;
+                        stateModel.reactionCountsOrder2().at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                     }
                     for(auto _it2 = it+1; _it2 != events.end(); ++_it2) {
                         if(_it2->idx1 == entry1 || _it2->idx2 == entry1 ||

--- a/kernels/cpu/src/actions/reactions/ReactionUtils.cpp
+++ b/kernels/cpu/src/actions/reactions/ReactionUtils.cpp
@@ -39,8 +39,7 @@ namespace reactions {
 
 data_t::update_t handleEventsGillespie(
         CPUKernel *const kernel, double timeStep, bool filterEventsInAdvance, bool approximateRate,
-        std::vector<event_t> &&events, std::vector<record_t> *maybeRecords, reaction_counts_order1_map *maybeCountsOrder1,
-        reaction_counts_order2_map *maybeCountsOrder2) {
+        std::vector<event_t> &&events, std::vector<record_t> *maybeRecords, reaction_counts_t *maybeCounts) {
     using rdy_particle_t = readdy::model::Particle;
     const auto& fixPos = kernel->getKernelContext().getFixPositionFun();
 
@@ -87,8 +86,8 @@ data_t::update_t handleEventsGillespie(
                             } else {
                                 performReaction(*data, entry1, entry1, newParticles, decayedEntries, reaction, nullptr);
                             }
-                            if(maybeCountsOrder1) {
-                                auto &countsOrder1 = *maybeCountsOrder1;
+                            if(maybeCounts) {
+                                auto &countsOrder1 = std::get<0>(*maybeCounts);
                                 countsOrder1.at(event.t1).at(event.reactionIdx)++;
                             }
                         } else {
@@ -104,8 +103,8 @@ data_t::update_t handleEventsGillespie(
                                 performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction,
                                                 nullptr);
                             }
-                            if(maybeCountsOrder2) {
-                                auto &countsOrder2 = *maybeCountsOrder2;
+                            if(maybeCounts) {
+                                auto &countsOrder2 = std::get<1>(*maybeCounts);
                                 countsOrder2.at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                             }
                         }

--- a/kernels/cpu/src/actions/reactions/ReactionUtils.cpp
+++ b/kernels/cpu/src/actions/reactions/ReactionUtils.cpp
@@ -39,7 +39,8 @@ namespace reactions {
 
 data_t::update_t handleEventsGillespie(
         CPUKernel *const kernel, double timeStep, bool filterEventsInAdvance, bool approximateRate,
-        std::vector<event_t> &&events, std::vector<record_t>* maybeRecords, reaction_counts_t* maybeCounts) {
+        std::vector<event_t> &&events, std::vector<record_t> *maybeRecords, reaction_counts_order1_map *maybeCountsOrder1,
+        reaction_counts_order2_map *maybeCountsOrder2) {
     using rdy_particle_t = readdy::model::Particle;
     const auto& fixPos = kernel->getKernelContext().getFixPositionFun();
 
@@ -86,8 +87,9 @@ data_t::update_t handleEventsGillespie(
                             } else {
                                 performReaction(*data, entry1, entry1, newParticles, decayedEntries, reaction, nullptr);
                             }
-                            if(maybeCounts) {
-                                std::get<0>(*maybeCounts).at(event.reactionIdx)++;
+                            if(maybeCountsOrder1) {
+                                auto &countsOrder1 = *maybeCountsOrder1;
+                                countsOrder1.at(event.t1).at(event.reactionIdx)++;
                             }
                         } else {
                             auto reaction = ctx.reactions().order2_by_type(event.t1, event.t2)[event.reactionIdx];
@@ -102,8 +104,9 @@ data_t::update_t handleEventsGillespie(
                                 performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction,
                                                 nullptr);
                             }
-                            if(maybeCounts) {
-                                std::get<1>(*maybeCounts).at(event.reactionIdx)++;
+                            if(maybeCountsOrder2) {
+                                auto &countsOrder2 = *maybeCountsOrder2;
+                                countsOrder2.at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                             }
                         }
                     }

--- a/kernels/cpu/src/observables/CPUObservables.cpp
+++ b/kernels/cpu/src/observables/CPUObservables.cpp
@@ -220,13 +220,7 @@ CPUReactionCounts::CPUReactionCounts(CPUKernel *const kernel, unsigned int strid
 
 void CPUReactionCounts::evaluate() {
     readdy::model::observables::ReactionCounts::initializeCounts(result, kernel->getKernelContext());
-    auto &reactionCounts = kernel->getCPUKernelStateModel().reactionCounts();
-    const auto& countsOrder1 = std::get<0>(reactionCounts);
-    const auto& countsOrder2 = std::get<1>(reactionCounts);
-    auto &resultOrder1 = std::get<0>(result);
-    auto &resultOrder2 = std::get<1>(result);
-    assignVectorsOfMap(countsOrder1, resultOrder1);
-    assignVectorsOfMap(countsOrder2, resultOrder2);
+    assignCountsToResult(kernel->getCPUKernelStateModel().reactionCounts(), result);
 }
 
 }

--- a/kernels/cpu/src/observables/CPUObservables.cpp
+++ b/kernels/cpu/src/observables/CPUObservables.cpp
@@ -219,15 +219,16 @@ CPUReactionCounts::CPUReactionCounts(CPUKernel *const kernel, unsigned int strid
         : ReactionCounts(kernel, stride), kernel(kernel) {}
 
 void CPUReactionCounts::evaluate() {
-    // the initialize is necessary if evaluate is called before the reaction counts have been recorded by the state-model/reaction-handler
-    // this becomes important not only when writing the result to file but also when other observables depend on this result
-    readdy::model::observables::util::initializeReactionCountMapping(std::get<0>(result), std::get<1>(result), kernel->getKernelContext());
-    auto &stateModel = kernel->getCPUKernelStateModel();
-    const auto& countsOrder1 = stateModel.reactionCountsOrder1();
-    const auto& countsOrder2 = stateModel.reactionCountsOrder2();
-
-    readdy::model::observables::util::copyCountsFromStateToResult(countsOrder1, countsOrder2, std::get<0>(result), std::get<1>(result));
+    readdy::model::observables::ReactionCounts::initializeCounts(result, kernel->getKernelContext());
+    auto &reactionCounts = kernel->getCPUKernelStateModel().reactionCounts();
+    const auto& countsOrder1 = std::get<0>(reactionCounts);
+    const auto& countsOrder2 = std::get<1>(reactionCounts);
+    auto &resultOrder1 = std::get<0>(result);
+    auto &resultOrder2 = std::get<1>(result);
+    assignVectorsOfMap(countsOrder1, resultOrder1);
+    assignVectorsOfMap(countsOrder2, resultOrder2);
 }
+
 }
 }
 }

--- a/kernels/singlecpu/src/actions/SCPUReactionImpls.cpp
+++ b/kernels/singlecpu/src/actions/SCPUReactionImpls.cpp
@@ -139,22 +139,12 @@ void SCPUUncontrolledApproximation::perform() {
     SCPUStateModel &stateModel = kernel->getSCPUKernelStateModel();
     if(ctx.recordReactionsWithPositions()) stateModel.reactionRecords().clear();
     if(ctx.recordReactionCounts()) {
-        auto& order1 = std::get<0>(stateModel.reactionCounts());
-        auto& order2 = std::get<1>(stateModel.reactionCounts());
-        if(order1.empty() && order2.empty()) {
-            const auto n_reactions_order1 = kernel->getKernelContext().reactions().n_order1();
-            const auto n_reactions_order2 = kernel->getKernelContext().reactions().n_order2();
-            order1.resize(n_reactions_order1);
-            order2.resize(n_reactions_order2);
-        } else {
-            std::fill(order1.begin(), order1.end(), 0);
-            std::fill(order2.begin(), order2.end(), 0);
-        }
+        auto &countsOrder1 = stateModel.reactionCountsOrder1();
+        auto &countsOrder2 = stateModel.reactionCountsOrder2();
+        readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
     }
     auto &data = *stateModel.getParticleData();
-    auto &nl = *stateModel.getNeighborList();
     auto events = findEvents(kernel, timeStep, true);
-
 
     // shuffle reactions
     std::random_shuffle(events.begin(), events.end());
@@ -179,7 +169,7 @@ void SCPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, fixPos, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        std::get<0>(stateModel.reactionCounts()).at(event.reactionIdx)++;
+                        stateModel.reactionCountsOrder1().at(event.t1).at(event.reactionIdx)++;
                     }
                     for (auto _it2 = it + 1; _it2 != events.end(); ++_it2) {
                         if (_it2->idx1 == entry1 || _it2->idx2 == entry1) {
@@ -194,11 +184,10 @@ void SCPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, &record);
                         stateModel.reactionRecords().push_back(record);
                     } else {
-                        performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos,
-                                        nullptr);
+                        performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        std::get<1>(stateModel.reactionCounts()).at(event.reactionIdx)++;
+                        stateModel.reactionCountsOrder2().at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                     }
                     for (auto _it2 = it + 1; _it2 != events.end(); ++_it2) {
                         if (_it2->idx1 == entry1 || _it2->idx2 == entry1 ||
@@ -330,7 +319,7 @@ data_t::update_t handleEventsGillespie(
                                                 nullptr);
                             }
                             if(ctx.recordReactionCounts()) {
-                                std::get<0>(model.reactionCounts()).at(event.reactionIdx)++;
+                                model.reactionCountsOrder1().at(event.t1).at(event.reactionIdx)++;
                             }
                         } else {
                             auto reaction = ctx.reactions().order2_by_type(event.t1, event.t2)[event.reactionIdx];
@@ -343,7 +332,7 @@ data_t::update_t handleEventsGillespie(
                                 performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, nullptr);
                             }
                             if(ctx.recordReactionCounts()) {
-                                std::get<1>(model.reactionCounts()).at(event.reactionIdx)++;
+                                model.reactionCountsOrder2().at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                             }
                         }
                     }
@@ -407,17 +396,9 @@ void SCPUGillespie::perform() {
     auto &stateModel = kernel->getSCPUKernelStateModel();
     if(ctx.recordReactionsWithPositions()) stateModel.reactionRecords().clear();
     if(ctx.recordReactionCounts()) {
-        auto& order1 = std::get<0>(stateModel.reactionCounts());
-        auto& order2 = std::get<1>(stateModel.reactionCounts());
-        if(order1.empty() && order2.empty()) {
-            const auto n_reactions_order1 = kernel->getKernelContext().reactions().n_order1();
-            const auto n_reactions_order2 = kernel->getKernelContext().reactions().n_order2();
-            order1.resize(n_reactions_order1);
-            order2.resize(n_reactions_order2);
-        } else {
-            std::fill(order1.begin(), order1.end(), 0);
-            std::fill(order2.begin(), order2.end(), 0);
-        }
+        auto &countsOrder1 = stateModel.reactionCountsOrder1();
+        auto &countsOrder2 = stateModel.reactionCountsOrder2();
+        readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
     }
     auto data = stateModel.getParticleData();
     const auto &dist = ctx.getDistSquaredFun();

--- a/kernels/singlecpu/src/actions/SCPUReactionImpls.cpp
+++ b/kernels/singlecpu/src/actions/SCPUReactionImpls.cpp
@@ -139,9 +139,7 @@ void SCPUUncontrolledApproximation::perform() {
     SCPUStateModel &stateModel = kernel->getSCPUKernelStateModel();
     if(ctx.recordReactionsWithPositions()) stateModel.reactionRecords().clear();
     if(ctx.recordReactionCounts()) {
-        auto &countsOrder1 = stateModel.reactionCountsOrder1();
-        auto &countsOrder2 = stateModel.reactionCountsOrder2();
-        readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
+        readdy::model::observables::ReactionCounts::initializeCounts(stateModel.reactionCounts(), ctx);
     }
     auto &data = *stateModel.getParticleData();
     auto events = findEvents(kernel, timeStep, true);
@@ -169,7 +167,8 @@ void SCPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, fixPos, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        stateModel.reactionCountsOrder1().at(event.t1).at(event.reactionIdx)++;
+                        auto &countsOrder1 = std::get<0>(stateModel.reactionCounts());
+                        countsOrder1.at(event.t1).at(event.reactionIdx)++;
                     }
                     for (auto _it2 = it + 1; _it2 != events.end(); ++_it2) {
                         if (_it2->idx1 == entry1 || _it2->idx2 == entry1) {
@@ -187,7 +186,8 @@ void SCPUUncontrolledApproximation::perform() {
                         performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, nullptr);
                     }
                     if(ctx.recordReactionCounts()) {
-                        stateModel.reactionCountsOrder2().at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
+                        auto &countsOrder2 = std::get<1>(stateModel.reactionCounts());
+                        countsOrder2.at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                     }
                     for (auto _it2 = it + 1; _it2 != events.end(); ++_it2) {
                         if (_it2->idx1 == entry1 || _it2->idx2 == entry1 ||
@@ -319,7 +319,8 @@ data_t::update_t handleEventsGillespie(
                                                 nullptr);
                             }
                             if(ctx.recordReactionCounts()) {
-                                model.reactionCountsOrder1().at(event.t1).at(event.reactionIdx)++;
+                                auto &countsOrder1 = std::get<0>(model.reactionCounts());
+                                countsOrder1.at(event.t1).at(event.reactionIdx)++;
                             }
                         } else {
                             auto reaction = ctx.reactions().order2_by_type(event.t1, event.t2)[event.reactionIdx];
@@ -332,7 +333,8 @@ data_t::update_t handleEventsGillespie(
                                 performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, nullptr);
                             }
                             if(ctx.recordReactionCounts()) {
-                                model.reactionCountsOrder2().at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
+                                auto &countsOrder2 = std::get<1>(model.reactionCounts());
+                                countsOrder2.at(std::tie(event.t1, event.t2)).at(event.reactionIdx)++;
                             }
                         }
                     }
@@ -396,9 +398,7 @@ void SCPUGillespie::perform() {
     auto &stateModel = kernel->getSCPUKernelStateModel();
     if(ctx.recordReactionsWithPositions()) stateModel.reactionRecords().clear();
     if(ctx.recordReactionCounts()) {
-        auto &countsOrder1 = stateModel.reactionCountsOrder1();
-        auto &countsOrder2 = stateModel.reactionCountsOrder2();
-        readdy::model::observables::util::initializeReactionCountMapping(countsOrder1, countsOrder2, ctx);
+        readdy::model::observables::ReactionCounts::initializeCounts(stateModel.reactionCounts(), ctx);
     }
     auto data = stateModel.getParticleData();
     const auto &dist = ctx.getDistSquaredFun();

--- a/readdy/main/model/IOUtils.cpp
+++ b/readdy/main/model/IOUtils.cpp
@@ -39,23 +39,25 @@ void writeReactionInformation(io::Group &group, const KernelContext &context) {
     auto groupO1 = subgroup.createGroup("./order1");
     auto groupO2 = subgroup.createGroup("./order2");
     for (const auto &t1 : context.particle_types().types_flat()) {
-        const auto &rO1 = context.reactions().order1_by_type(t1);
-        std::vector<std::string> lO1;
-        lO1.reserve(rO1.size());
-        std::for_each(rO1.begin(), rO1.end(), [&lO1](reactions::Reaction<1> *r) { lO1.push_back(r->getName()); });
-        if (!lO1.empty()) {
-            groupO1.write(context.particle_types().name_of(t1) + "[id=" + std::to_string(t1) + "]", lO1);
+        const auto &reactionsOrder1 = context.reactions().order1_by_type(t1);
+        std::vector<std::string> labelsOrder1;
+        labelsOrder1.reserve(reactionsOrder1.size());
+        std::for_each(reactionsOrder1.begin(), reactionsOrder1.end(),
+                      [&labelsOrder1](reactions::Reaction<1> *r) { labelsOrder1.push_back(r->getName()); });
+        if (!labelsOrder1.empty()) {
+            groupO1.write(context.particle_types().name_of(t1) + "[id=" + std::to_string(t1) + "]", labelsOrder1);
         }
         for (const auto &t2 : context.particle_types().types_flat()) {
             if (t2 < t1) continue;
-            const auto &rO2 = context.reactions().order2_by_type(t1, t2);
-            std::vector<std::string> lO2;
-            lO2.reserve(rO2.size());
-            std::for_each(rO2.begin(), rO2.end(), [&lO2](reactions::Reaction<2> *r) { lO2.push_back(r->getName()); });
-            if (!lO2.empty()) {
+            const auto &reactionsOrder2 = context.reactions().order2_by_type(t1, t2);
+            std::vector<std::string> labelsOrder2;
+            labelsOrder2.reserve(reactionsOrder2.size());
+            std::for_each(reactionsOrder2.begin(), reactionsOrder2.end(),
+                          [&labelsOrder2](reactions::Reaction<2> *r) { labelsOrder2.push_back(r->getName()); });
+            if (!labelsOrder2.empty()) {
                 groupO2.write(
                         context.particle_types().name_of(t1) + "[id=" + std::to_string(t1) + "] + " +
-                                context.particle_types().name_of(t2) + "[id=" + std::to_string(t2) + "]", lO2);
+                        context.particle_types().name_of(t2) + "[id=" + std::to_string(t2) + "]", labelsOrder2);
             }
         }
     }

--- a/readdy/main/model/observables/ReactionCounts.cpp
+++ b/readdy/main/model/observables/ReactionCounts.cpp
@@ -131,10 +131,10 @@ void ReactionCounts::append() {
 
     // actual writing of data
     const auto &countsOrder1 = std::get<0>(result);
-    util::writeCountsToDataSets(countsOrder1, pimpl->ds_order1);
+    writeCountsToDataSets(countsOrder1, pimpl->ds_order1);
 
     const auto &countsOrder2 = std::get<1>(result);
-    util::writeCountsToDataSets(countsOrder2, pimpl->ds_order2);
+    writeCountsToDataSets(countsOrder2, pimpl->ds_order2);
 
     pimpl->time->append(t_current);
 }

--- a/readdy/main/model/observables/ReactionCounts.cpp
+++ b/readdy/main/model/observables/ReactionCounts.cpp
@@ -45,22 +45,27 @@ namespace observables {
 struct ReactionCounts::Impl {
     using data_set_t = io::DataSet<std::size_t, false>;
     std::unique_ptr<io::Group> group;
-    std::unique_ptr<data_set_t> ds_order1;
-    std::unique_ptr<data_set_t> ds_order2;
+    std::unordered_map<readdy::model::Particle::type_type, std::unique_ptr<data_set_t>> ds_order1;
+    std::unordered_map<readdy::util::particle_type_pair, std::unique_ptr<data_set_t>,
+            readdy::util::particle_type_pair_hasher, readdy::util::particle_type_pair_equal_to> ds_order2;
     std::unique_ptr<util::TimeSeriesWriter> time;
     bool shouldWrite = false;
     unsigned int flushStride = 0;
     bool firstWrite = true;
+    std::function<void(std::unique_ptr<data_set_t>&)> flushFun = [](std::unique_ptr<data_set_t> &value){
+        if (value) {
+            value->flush();
+        }
+    };
 };
 
 ReactionCounts::ReactionCounts(Kernel *const kernel, unsigned int stride)
         : Observable(kernel, stride), pimpl(std::make_unique<Impl>()) {
-    result = std::make_tuple(std::vector<std::size_t>(), std::vector<std::size_t>());
 }
 
 void ReactionCounts::flush() {
-    if (pimpl->ds_order1) pimpl->ds_order1->flush();
-    if (pimpl->ds_order2) pimpl->ds_order2->flush();
+    readdy::util::collections::for_each_value_in_map(pimpl->ds_order1, pimpl->flushFun);
+    readdy::util::collections::for_each_value_in_map(pimpl->ds_order2, pimpl->flushFun);
     if (pimpl->time) pimpl->time->flush();
 }
 
@@ -84,36 +89,53 @@ void ReactionCounts::initializeDataSet(io::File &file, const std::string &dataSe
 
 void ReactionCounts::append() {
     if (pimpl->firstWrite) {
-        const auto n_reactions_order1 = kernel->getKernelContext().reactions().n_order1();
-        const auto n_reactions_order2 = kernel->getKernelContext().reactions().n_order2();
-        std::get<0>(result).resize(n_reactions_order1);
-        std::get<1>(result).resize(n_reactions_order2);
+        const auto &ctx = kernel->getKernelContext();
         if (pimpl->shouldWrite) {
             auto subgroup = pimpl->group->createGroup("counts");
-            if(n_reactions_order1 > 0){
-                std::vector<readdy::io::h5::dims_t> fs = {pimpl->flushStride, n_reactions_order1};
-                std::vector<readdy::io::h5::dims_t> dims = {readdy::io::h5::UNLIMITED_DIMS, n_reactions_order1};
-                auto dataSetTypes = std::make_unique<Impl::data_set_t>("order1", subgroup, fs, dims);
-                pimpl->ds_order1 = std::move(dataSetTypes);
+            auto order1Subgroup = subgroup.createGroup("order1");
+            for (const auto &entry : ctx.particle_types().type_mapping()) {
+                const auto &pType = entry.second;
+                const auto numberOrder1Reactions = ctx.reactions().order1_by_type(pType).size();
+                if (numberOrder1Reactions > 0) {
+                    std::vector<readdy::io::h5::dims_t> chunkSize = {pimpl->flushStride, numberOrder1Reactions};
+                    std::vector<readdy::io::h5::dims_t> dims = {readdy::io::h5::UNLIMITED_DIMS, numberOrder1Reactions};
+                    auto dataSet = std::make_unique<Impl::data_set_t>(
+                            ctx.particle_types().name_of(pType) + "[id=" + std::to_string(pType) + "]",
+                            order1Subgroup, chunkSize, dims);
+                    pimpl->ds_order1[pType] = std::move(dataSet);
+                }
             }
-            if(n_reactions_order2 > 0){
-                std::vector<readdy::io::h5::dims_t> fs = {pimpl->flushStride, n_reactions_order2};
-                std::vector<readdy::io::h5::dims_t> dims = {readdy::io::h5::UNLIMITED_DIMS, n_reactions_order2};
-                auto dataSetTypes = std::make_unique<Impl::data_set_t>("order2", subgroup, fs, dims);
-                pimpl->ds_order2 = std::move(dataSetTypes);
+            auto order2Subgroup = subgroup.createGroup("order2");
+            for (const auto &entry1 : ctx.particle_types().type_mapping()) {
+                const auto &pType1 = entry1.second;
+                for (const auto &entry2 : ctx.particle_types().type_mapping()) {
+                    const auto &pType2 = entry2.second;
+                    if (pType2 < pType1) continue;
+                    const auto numberOrder2Reactions = ctx.reactions().order2_by_type(pType1, pType2).size();
+                    if (numberOrder2Reactions > 0) {
+                        std::vector<readdy::io::h5::dims_t> chunkSize = {pimpl->flushStride, numberOrder2Reactions};
+                        std::vector<readdy::io::h5::dims_t> dims = {readdy::io::h5::UNLIMITED_DIMS, numberOrder2Reactions};
+                        auto dataSet = std::make_unique<Impl::data_set_t>(
+                                ctx.particle_types().name_of(pType1) + "[id=" + std::to_string(pType1) + "] + " +
+                                ctx.particle_types().name_of(pType2) + "[id=" + std::to_string(pType2) + "]",
+                                order2Subgroup, chunkSize, dims);
+                        readdy::util::particle_type_pair particleTypePair(pType1, pType2);
+                        pimpl->ds_order2[particleTypePair] = std::move(dataSet);
+                    }
+                }
             }
             writeReactionInformation(*pimpl->group, kernel->getKernelContext());
         }
         pimpl->firstWrite = false;
     }
-    if(pimpl->ds_order1){
-        auto &order1Reactions = std::get<0>(result);
-        pimpl->ds_order1->append({1, order1Reactions.size()}, order1Reactions.data());
-    }
-    if(pimpl->ds_order2){
-        auto &order2Reactions = std::get<1>(result);
-        pimpl->ds_order2->append({1, order2Reactions.size()}, order2Reactions.data());
-    }
+
+    // actual writing of data
+    const auto &countsOrder1 = std::get<0>(result);
+    util::writeCountsToDataSets(countsOrder1, pimpl->ds_order1);
+
+    const auto &countsOrder2 = std::get<1>(result);
+    util::writeCountsToDataSets(countsOrder2, pimpl->ds_order2);
+
     pimpl->time->append(t_current);
 }
 

--- a/readdy/main/model/reactions/ReactionRegistry.cpp
+++ b/readdy/main/model/reactions/ReactionRegistry.cpp
@@ -98,14 +98,14 @@ void ReactionRegistry::configure() {
     one_educt_registry.clear();
     two_educts_registry.clear();
     coll::for_each_value(one_educt_registry_internal,
-                         [&](const particle_t::type_type type, const reaction1ptr &ptr) {
+                         [&](const particle_type_type type, const reaction1ptr &ptr) {
                              (one_educt_registry)[type].push_back(ptr.get());
                          });
     coll::for_each_value(two_educts_registry_internal, [&](const pair &type, const reaction2ptr &r) {
         (two_educts_registry)[type].push_back(r.get());
     });
     coll::for_each_value(one_educt_registry_external,
-                         [&](const particle_t::type_type type, reactions::Reaction<1> *ptr) {
+                         [&](const particle_type_type type, reactions::Reaction<1> *ptr) {
                              (one_educt_registry)[type].push_back(ptr);
                          });
     coll::for_each_value(two_educts_registry_external, [&](const pair &type, reactions::Reaction<2> *r) {


### PR DESCRIPTION
ReactionCounts have a new result type, which is a map instead of a flattened vector, this structure is preserved from the state model to the observable up to the dataset in the written file. This is necessary to be able to identify the type of reaction later on in the output file.