### PR TITLE
Fix false positioning in Fusion reaction

### DIFF
--- a/include/readdy/kernel/singlecpu/actions/SCPUReactionUtils.h
+++ b/include/readdy/kernel/singlecpu/actions/SCPUReactionUtils.h
@@ -109,7 +109,7 @@ void performReaction(
             if (reaction->getEducts()[0] == entry1.type) {
                 entry1.pos += reaction->getWeight1() * (e2Pos - e1Pos);
             } else {
-                entry1.pos += reaction->getWeight1() * (e1Pos - e2Pos);
+                entry1.pos += reaction->getWeight2() * (e2Pos - e1Pos);
             }
             fixPos(entry1.pos);
             entry1.type = reaction->getProducts()[0];

--- a/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
@@ -183,7 +183,7 @@ void performReaction(data_t& data, data_t::index_t idx1, data_t::index_t idx2, d
             if (reaction->getEducts()[0] == entry1.type) {
                 data.displace(entry1, reaction->getWeight1() * (e2Pos - e1Pos));
             } else {
-                data.displace(entry1, reaction->getWeight1() * (e1Pos - e2Pos));
+                data.displace(entry1, reaction->getWeight2() * (e2Pos - e1Pos));
             }
             entry1.type = reaction->getProducts()[0];
             entry1.id = readdy::model::Particle::nextId();

--- a/kernels/cpu_dense/include/readdy/kernel/cpu_dense/actions/reactions/ReactionUtils.h
+++ b/kernels/cpu_dense/include/readdy/kernel/cpu_dense/actions/reactions/ReactionUtils.h
@@ -163,7 +163,7 @@ void performReaction(data_t& data, data_t::index_t idx1, data_t::index_t idx2, d
             if (reaction->getEducts()[0] == entry1.type) {
                 data.displace(entry1, reaction->getWeight1() * (e2Pos - e1Pos));
             } else {
-                data.displace(entry1, reaction->getWeight1() * (e1Pos - e2Pos));
+                data.displace(entry1, reaction->getWeight2() * (e2Pos - e1Pos));
             }
             entry1.type = reaction->getProducts()[0];
             data.deactivate(entry2);


### PR DESCRIPTION
- While simulating a system - where some particles participate in Fusion/Fission reactions, but their diffusion constants and reaction-weights were chosen, such that they never move - some of them moved during a fusion reaction. But this occured not in all fusion events. It turns out that the particles were positioned wrong only in the `else` clause, while identifying the educts (see the changed lines in the ReactionUtils).
- Added test to catch that scenario.