### PR TITLE
Load kernels on import

### DIFF
--- a/wrappers/python/src/python/readdy/_internal/__init__.py
+++ b/wrappers/python/src/python/readdy/_internal/__init__.py
@@ -22,7 +22,12 @@
 
 # load kernels automagically
 import readdy.util.platform_utils as putils
-from .readdybinding import api
+from .readdybinding.api import *
+from .readdybinding.common import *
+from .readdybinding.common.io import *
+from .readdybinding.common.util import *
 
-kernel_provider = api.KernelProvider.get()
+register_blosc_hdf5_plugin()
+
+kernel_provider = KernelProvider.get()
 kernel_provider.load_from_dir(putils.get_readdy_plugin_dir())

--- a/wrappers/python/src/python/readdy/_internal/__init__.py
+++ b/wrappers/python/src/python/readdy/_internal/__init__.py
@@ -19,3 +19,10 @@
 # Public License along with this program. If not, see
 # <http://www.gnu.org/licenses/>.
 
+
+# load kernels automagically
+import readdy.util.platform_utils as putils
+from .readdybinding import api
+
+kernel_provider = api.KernelProvider.get()
+kernel_provider.load_from_dir(putils.get_readdy_plugin_dir())


### PR DESCRIPTION
- Raise the low level modules of the c-extension into the readdy._internal namespace
- Kernels are automatically loaded from conda environment
- Init blosc (data compression filter) plugin on import

Usage
```python
import readdy._internal as lowlevelapi
sim = lowlevelapi.Simulation()
sim.set_kernel("CPU")
...
```