### PR TITLE
Units and sanity checking for box potential with non-periodic b.c.

### DIFF
--- a/include/readdy/model/Context.h
+++ b/include/readdy/model/Context.h
@@ -96,6 +96,11 @@ public:
     const compartments::CompartmentRegistry &compartments() const;
 
     /**
+     * Method for sanity checking at least some parts of the configuration. It should only be called after configure().
+     */
+    void validate() const;
+
+    /**
      * Copy the reactions and potentials of the internal and external registries into the actual registries, which
      * is used during the run of the simulation. This step is necessary before the simulation can start. Otherwise the
      * registered reactions and potentials will not take effect. The context is optionally logged in text format.

--- a/include/readdy/model/potentials/Potential.h
+++ b/include/readdy/model/potentials/Potential.h
@@ -67,6 +67,8 @@ public:
 
     virtual std::string describe() const = 0;
 
+    virtual std::string type() const = 0;
+
     friend std::ostream &operator<<(std::ostream &os, const Potential &potential) {
         os << potential.describe();
         return os;

--- a/include/readdy/model/potentials/PotentialsOrder1.h
+++ b/include/readdy/model/potentials/PotentialsOrder1.h
@@ -64,6 +64,8 @@ public:
 
     std::string describe() const override;
 
+    std::string type() const override;
+
 protected:
     const Vec3 origin, extent, min, max;
     const scalar forceConstant;
@@ -87,6 +89,8 @@ public:
 
     std::string describe() const override;
 
+    std::string type() const override;
+
 protected:
     const Vec3 origin;
     const scalar radius, forceConstant;
@@ -108,6 +112,9 @@ public:
     void calculateForceAndEnergy(Vec3 &force, scalar &energy, const Vec3 &position) const override;
 
     std::string describe() const override;
+
+    std::string type() const override;
+
 protected:
     const Vec3 origin;
     const scalar radius, forceConstant;
@@ -134,6 +141,8 @@ public:
     void calculateForceAndEnergy(Vec3 &force, readdy::scalar &energy, const Vec3 &position) const override;
 
     std::string describe() const override;
+
+    std::string type() const override;
 
 protected:
     const Vec3 origin;

--- a/include/readdy/model/potentials/PotentialsOrder2.h
+++ b/include/readdy/model/potentials/PotentialsOrder2.h
@@ -64,6 +64,8 @@ public:
 
     scalar getCutoffRadiusSquared() const override;
 
+    std::string type() const override;
+
 protected:
     scalar _interactionDistance;
     scalar _interactionDistanceSquared;
@@ -101,6 +103,8 @@ public:
     scalar getCutoffRadius() const override;
 
     scalar getCutoffRadiusSquared() const override;
+
+    std::string type() const override;
 
 protected:
     const Configuration conf;
@@ -163,6 +167,8 @@ public:
 
     scalar getMaximalForce(scalar kbt) const noexcept override;
 
+    std::string type() const override;
+
 protected:
     scalar energy(scalar r) const;
 
@@ -204,6 +210,8 @@ public:
     scalar getCutoffRadiusSquared() const override;
 
     scalar getMaximalForce(scalar kbt) const noexcept override;
+
+    std::string type() const override;
 
 protected:
     scalar electrostaticStrength;

--- a/include/readdy/model/topologies/graph/Graph.h
+++ b/include/readdy/model/topologies/graph/Graph.h
@@ -109,7 +109,11 @@ public:
     void removeParticle(std::size_t particleIndex);
 
     bool isConnected();
+    
+    std::vector<std::tuple<vertex_ref, vertex_ref>> edges();
 
+    void findEdges(const edge_callback &edgeCallback);
+    
     void findNTuples(const edge_callback &tuple_callback,
                      const path_len_2_callback &triple_callback,
                      const path_len_3_callback &quadruple_callback);

--- a/kernels/cpu/test/TestNeighborList.cpp
+++ b/kernels/cpu/test/TestNeighborList.cpp
@@ -132,6 +132,7 @@ TEST_F(TestNeighborList, OneDirection) {
     auto &ctx = kernel->context();
     ctx.boxSize() = {{1.2, 1.1, 2.8}};
     ctx.periodicBoundaryConditions() = {{false, false, true}};
+    ctx.potentials().addBox("A", .0, {-.4, -.4, -1.3}, {.4, .4, 1.3});
     ctx.configure(false);
 
     readdy::util::thread::Config conf;

--- a/kernels/cpu/test/TestReactions.cpp
+++ b/kernels/cpu/test/TestReactions.cpp
@@ -274,6 +274,9 @@ TEST(CPUTestReactions, TestGillespieParallel) {
     kernel->context().particle_types().add("A", .25);
     kernel->context().particle_types().add("B", .25);
     kernel->context().particle_types().add("C", .25);
+    kernel->context().potentials().addBox("A", .0001, {-4.9, -4.9, -14.9}, {9.8, 9.8, 29.8});
+    kernel->context().potentials().addBox("B", .0001, {-4.9, -4.9, -14.9}, {9.8, 9.8, 29.8});
+    kernel->context().potentials().addBox("C", .0001, {-4.9, -4.9, -14.9}, {9.8, 9.8, 29.8});
     readdy::scalar reactionRadius = 1.0;
     kernel->context().reactions().addFusion("annihilation", "A", "A", "A", 1.0, reactionRadius);
     kernel->context().reactions().addFusion("very unlikely", "A", "C", "A", std::numeric_limits<readdy::scalar>::min(), reactionRadius);

--- a/readdy/main/model/IOUtils.cpp
+++ b/readdy/main/model/IOUtils.cpp
@@ -55,7 +55,7 @@ void writeReactionInformation(h5rd::Group &group, const Context &context) {
                           r->productDistance(), r->educts(), r->products()};
         reactionInfos.push_back(info);
     }
-    {
+    if(!reactionInfos.empty()) {
         auto types = getReactionInfoMemoryType(group.parentFile());
         h5rd::dimensions dims = {h5rd::UNLIMITED_DIMS};
         h5rd::dimensions extent = {reactionInfos.size()};

--- a/readdy/main/model/potentials/Potentials.cpp
+++ b/readdy/main/model/potentials/Potentials.cpp
@@ -131,6 +131,10 @@ std::string Box::describe() const {
     return ss.str();
 }
 
+std::string Box::type() const {
+    return getPotentialName<Box>();
+}
+
 /*
  * Sphere Potentials
  */
@@ -183,6 +187,10 @@ std::string SphereIn::describe() const {
     return ss.str();
 }
 
+std::string SphereIn::type() const {
+    return getPotentialName<SphereIn>();
+}
+
 SphereOut::SphereOut(particle_type_type particleType, scalar forceConstant, const Vec3 &origin, scalar radius)
         : super(particleType), forceConstant(forceConstant), origin(origin), radius(radius) {}
 
@@ -229,6 +237,10 @@ void SphereOut::calculateForceAndEnergy(Vec3 &force, scalar &energy, const Vec3 
         energy += 0.5 * forceConstant * distanceFromSphere * distanceFromSphere;
         force += -1 * forceConstant * distanceFromSphere * difference / distanceFromOrigin;
     }
+}
+
+std::string SphereOut::type() const {
+    return getPotentialName<SphereOut>();
 }
 
 SphericalBarrier::SphericalBarrier(particle_type_type particleType, scalar height, scalar width, const Vec3 &origin, scalar radius)
@@ -314,6 +326,10 @@ std::string SphericalBarrier::describe() const {
     return ss.str();
 }
 
+std::string SphericalBarrier::type() const {
+    return getPotentialName<SphericalBarrier>();
+}
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Potentials order 2
@@ -386,6 +402,10 @@ std::string HarmonicRepulsion::describe() const {
 
 scalar HarmonicRepulsion::interactionDistance() const {
     return _interactionDistance;
+}
+
+std::string HarmonicRepulsion::type() const {
+    return getPotentialName<HarmonicRepulsion>();
 }
 
 /**
@@ -481,6 +501,10 @@ std::string WeakInteractionPiecewiseHarmonic::describe() const {
     return ss.str();
 }
 
+std::string WeakInteractionPiecewiseHarmonic::type() const {
+    return getPotentialName<HarmonicRepulsion>();
+}
+
 WeakInteractionPiecewiseHarmonic::Configuration::Configuration(const scalar  desiredParticleDistance,
                                                                const scalar  depthAtDesiredDistance,
                                                                const scalar  noInteractionDistance)
@@ -547,6 +571,10 @@ std::string LennardJones::describe() const {
     return ss.str();
 }
 
+std::string LennardJones::type() const {
+    return getPotentialName<LennardJones>();
+}
+
 LennardJones::~LennardJones() = default;
 
 
@@ -611,6 +639,10 @@ void ScreenedElectrostatics::calculateForce(Vec3 &force, const Vec3 &x_ij) const
 void ScreenedElectrostatics::calculateForceAndEnergy(Vec3 &force, scalar  &energy, const Vec3 &x_ij) const {
     calculateForce(force, x_ij);
     energy += calculateEnergy(x_ij);
+}
+
+std::string ScreenedElectrostatics::type() const {
+    return getPotentialName<ScreenedElectrostatics>();
 }
 
 ScreenedElectrostatics::~ScreenedElectrostatics() = default;

--- a/readdy/main/model/topologies/graph/Graph.cpp
+++ b/readdy/main/model/topologies/graph/Graph.cpp
@@ -146,6 +146,21 @@ bool Graph::isConnected() {
     return n_visited == _vertices.size();
 }
 
+void Graph::findEdges(const Graph::edge_callback &edgeCallback) {
+    for (auto &v : _vertices) {
+        v.visited = false;
+    }
+    
+    for(auto it = _vertices.begin(); it != _vertices.end(); ++it) {
+        auto &neighbors = it->neighbors();
+        for (auto it_neigh : neighbors) {
+            if(!it_neigh->visited) {
+                edgeCallback(std::tie(it, it_neigh));
+            }
+        }
+    }
+}
+
 void Graph::findNTuples(const edge_callback &tuple_callback,
                         const path_len_2_callback &triple_callback,
                         const path_len_3_callback &quadruple_callback) {
@@ -291,6 +306,14 @@ bool Graph::containsEdge(const Graph::cedge &edge) const {
 
 bool Graph::containsEdge(const Graph::vertex_cref v1, const Graph::vertex_cref v2) const {
     return containsEdge(std::tie(v1, v2));
+}
+
+std::vector<std::tuple<Graph::vertex_ref, Graph::vertex_ref>> Graph::edges() {
+    std::vector<std::tuple<Graph::vertex_ref, Graph::vertex_ref>> result;
+    findEdges([&result](const edge& tup) {
+        result.push_back(tup);
+    });
+    return result;
 }
 
 }

--- a/readdy/test/TestObservables.cpp
+++ b/readdy/test/TestObservables.cpp
@@ -113,6 +113,9 @@ TEST_P(TestObservables, TestForcesObservable) {
     kernel->context().periodicBoundaryConditions() = {{false, false, false}};
     kernel->context().boxSize() = {{5, 5, 5}};
     kernel->context().particle_types().add("C", 1.);
+    kernel->context().potentials().addBox("A", .001, {-2.4, -2.4, -2.4}, {4.8, 4.8, 4.8});
+    kernel->context().potentials().addBox("B", .001, {-2.4, -2.4, -2.4}, {4.8, 4.8, 4.8});
+    kernel->context().potentials().addBox("C", .001, {-2.4, -2.4, -2.4}, {4.8, 4.8, 4.8});
     const auto typeIdC = kernel->context().particle_types().idOf("C");
     const auto particlesC = std::vector<m::Particle>{m::Particle(0, 0, 0, typeIdC), m::Particle(0, -1.5, 0, typeIdC)};
     kernel->stateModel().addParticles(particlesC);

--- a/readdy/test/TestPotentials.cpp
+++ b/readdy/test/TestPotentials.cpp
@@ -200,6 +200,7 @@ TEST_P(TestPotentials, ScreenedElectrostatics) {
     ctx.periodicBoundaryConditions() = {{false, false, false}};
     ctx.particle_types().add("A", 1.0);
     ctx.boxSize() = {{10, 10, 10}};
+    ctx.potentials().addBox("A", .001, {-4.9, -4.9, -4.9}, {9.8, 9.8, 9.8});
     // distance of particles is 2.56515106768
     auto id0 = kernel->addParticle("A", {0, 0, 0});
     auto id1 = kernel->addParticle("A", {1.2, 1.5, -1.7});

--- a/readdy/test/TestStateModel.cpp
+++ b/readdy/test/TestStateModel.cpp
@@ -51,7 +51,10 @@ TEST_P(TestStateModel, CalculateForcesTwoParticles) {
     ctx.boxSize() = {{4., 4., 4.}};
     ctx.periodicBoundaryConditions() = {{false, false, false}};
 
+    ctx.potentials().addBox("A", .001, {-1.9, -1.9, -1.9}, {3.8, 3.8, 3.8});
+
     kernel->context().potentials().addHarmonicRepulsion("A", "A", 1.0, 2.0);
+    kernel->context().potentials().addBox("A", .01, {-1.9, -1.9, -1.9}, {3.8, 3.8, 3.8});
 
     ctx.configure();
     kernel->initialize();
@@ -99,6 +102,8 @@ TEST_P(TestStateModel, CalculateForcesRepulsion) {
     ctx.boxSize() = {{10., 10., 10.}};
     ctx.periodicBoundaryConditions() = {{true, true, false}};
     ctx.potentials().addHarmonicRepulsion("A", "B", 1.0, 3.0);
+    kernel->context().potentials().addBox("A", .01, {-4.9, -4.9, -4.9}, {9.8, 9.8, 9.8});
+    kernel->context().potentials().addBox("B", .01, {-4.9, -4.9, -4.9}, {9.8, 9.8, 9.8});
 
     ctx.configure();
     auto typeIdA = ctx.particle_types().idOf("A");
@@ -212,6 +217,8 @@ TEST_P(TestStateModel, CalculateForcesNoForces) {
     ctx.particle_types().add("B", 1.0);
     ctx.boxSize() = {{4., 4., 4.}};
     ctx.periodicBoundaryConditions() = {{false, false, false}};
+    ctx.potentials().addBox("A", .00000001, {-1.9, -1.9, -1.9}, {3.85, 3.85, 3.85});
+    ctx.potentials().addBox("B", .00000001, {-1.9, -1.9, -1.9}, {3.85, 3.85, 3.85});
     ctx.configure();
     auto typeIdA = ctx.particle_types().idOf("A");
     auto typeIdB = ctx.particle_types().idOf("B");

--- a/readdy_testing/include/readdy/testing/NOOPPotential.h
+++ b/readdy_testing/include/readdy/testing/NOOPPotential.h
@@ -54,6 +54,10 @@ struct NOOPPotentialOrder2 : public readdy::model::potentials::PotentialOrder2 {
         return energy;
     }
 
+    virtual std::string type() const override {
+        return "noop pot";
+    }
+
     virtual void calculateForce(Vec3 &force, const Vec3 &x_ij) const override {
         force[0] = NOOPPotentialOrder2::force;
         force[1] = NOOPPotentialOrder2::force;

--- a/tools/conda-recipe/meta.yaml
+++ b/tools/conda-recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - numpy
     - h5py
     - progress_reporter
+    - pint
     - hdf5
     - networkx
     - matplotlib

--- a/wrappers/python/src/cxx/api/ExportTopologies.cpp
+++ b/wrappers/python/src/cxx/api/ExportTopologies.cpp
@@ -145,6 +145,15 @@ void exportTopologies(py::module &m) {
                 :param v_index2: index of the second vertex, as in `topology.get_graph().get_vertices()`
                 :return: a reference to this recipe to enable a fluent interface
             )topdoc", "v_index1"_a, "v_index2"_a, py::return_value_policy::reference_internal)
+            .def("remove_edge", [](reaction_recipe &self, graph::edge edge) -> reaction_recipe& {
+                return self.removeEdge(edge);
+            }, R"topdoc(
+                Removes an edge between given vertices. Depending on the configuration of the topology reaction, this
+                can lead to failed states or multiple sub-topologies.
+
+                :param edge: the edge
+                :return: a reference to this recipe to enable a fluent interface
+            )topdoc", "edge"_a, py::return_value_policy::reference_internal)
             .def("separate_vertex", [](reaction_recipe &self, const std::size_t index) -> reaction_recipe& {
                 auto it = self.topology().graph().vertices().begin();
                 std::advance(it, index);
@@ -239,6 +248,13 @@ void exportTopologies(py::module &m) {
 
                 :return: list of vertices
             )topdoc",rvp::reference_internal)
+            .def("get_edges", [](graph &self) -> std::vector<graph::edge> {
+                return self.edges();
+            }, R"topdoc(
+                Yields a list of edges contained in this graph.
+
+                :return: list of edges
+            )topdoc")
             .def("add_edge", [](graph &self, std::size_t v1, std::size_t v2) {
                 if (v1 < self.vertices().size() && v2 < self.vertices().size()) {
                     if(v2 < v1) std::swap(v1, v2);

--- a/wrappers/python/src/cxx/api/PyPotential.cpp
+++ b/wrappers/python/src/cxx/api/PyPotential.cpp
@@ -69,6 +69,10 @@ std::string PotentialOrder2Wrapper::describe() const {
     return "Python wrapped potential order 2";
 }
 
+std::string PotentialOrder2Wrapper::type() const {
+    return describe();
+}
+
 
 }
 

--- a/wrappers/python/src/cxx/api/PyPotential.h
+++ b/wrappers/python/src/cxx/api/PyPotential.h
@@ -44,24 +44,25 @@ public:
     PotentialOrder2Wrapper(particle_type_type particleType1, particle_type_type particleType2,
                            pybind11::object o1, pybind11::object o2);
 
-    virtual readdy::scalar calculateEnergy(const Vec3 &x_ij) const override;
+    readdy::scalar calculateEnergy(const Vec3 &x_ij) const override;
 
-    virtual void calculateForce(Vec3 &force, const Vec3 &x_ij) const override;
+    void calculateForce(Vec3 &force, const Vec3 &x_ij) const override;
 
-    virtual void calculateForceAndEnergy(Vec3 &force, readdy::scalar &energy, const Vec3 &x_ij) const override;
+    void calculateForceAndEnergy(Vec3 &force, readdy::scalar &energy, const Vec3 &x_ij) const override;
 
-    virtual readdy::scalar getCutoffRadius() const override {
+    readdy::scalar getCutoffRadius() const override {
         // todo!
         return 50;
     }
 
-    virtual readdy::scalar getMaximalForce(readdy::scalar kbt) const noexcept override {
+    readdy::scalar getMaximalForce(readdy::scalar kbt) const noexcept override {
         // todo!
         return 0;
     }
 
-    virtual readdy::scalar getCutoffRadiusSquared() const override;
+    readdy::scalar getCutoffRadiusSquared() const override;
 
+    std::string type() const override;
 
 protected:
     std::shared_ptr<pybind11::object> calcEnergyFun;

--- a/wrappers/python/src/cxx/prototyping/ExportPotentials.cpp
+++ b/wrappers/python/src/cxx/prototyping/ExportPotentials.cpp
@@ -76,6 +76,10 @@ public:
         PYBIND11_OVERLOAD_PURE_NAME(readdy::scalar, rdy_pot1, "get_maximal_force", getMaximalForce, kbt);
     }
 
+    std::string type() const override {
+        return "Python defined potential of order 1";
+    }
+
 };
 
 class PyPotentialO2 : public rdy_pot2 {
@@ -119,6 +123,10 @@ public:
     readdy::scalar getCutoffRadius() const override {
         py::gil_scoped_acquire gil;
         PYBIND11_OVERLOAD_PURE_NAME(readdy::scalar, rdy_pot2, "get_cutoff_radius", getCutoffRadius);
+    }
+
+    std::string type() const override {
+        return "Python defined potential of order 2";
     }
 
 };

--- a/wrappers/python/src/python/readdy/__init__.py
+++ b/wrappers/python/src/python/readdy/__init__.py
@@ -22,6 +22,7 @@
 from .api.reaction_diffusion_system import *
 from .api.simulation import *
 from .api.trajectory import Trajectory
+from .api.conf import ureg as units
 
 # elevate reaction recipe
 from ._internal.readdybinding.api.top import Recipe as StructuralReactionRecipe

--- a/wrappers/python/src/python/readdy/api/conf/UnitConfiguration.py
+++ b/wrappers/python/src/python/readdy/api/conf/UnitConfiguration.py
@@ -30,26 +30,62 @@ from . import Q_ as _Q_
 
 
 class UnitConfiguration(object):
-    def __init__(self, length_unit='nanometer', time_unit='nanosecond', energy_unit='kilojoule/mol'):
+    def __init__(self, length_unit='nanometer', time_unit='nanosecond', energy_unit='kilojoule/mol',
+                 temperature_unit='kelvin'):
         self._length_unit = _ureg.parse_units(length_unit)
         self._time_unit = _ureg.parse_units(time_unit)
         self._energy_unit = _ureg.parse_units(energy_unit)
+        self._temperature_unit = _ureg.parse_units(temperature_unit)
+        self._boltzmann = _ureg.parse_units('boltzmann_constant')
+        self._avogadro = _ureg.parse_units('avogadro_number')
 
     @property
     def reg(self):
         return _ureg
 
     @property
+    def boltzmann(self):
+        return self._boltzmann
+
+    @property
+    def avogadro(self):
+        return self._avogadro
+
+    @property
+    def temperature_unit(self):
+        return self._temperature_unit
+
+    @temperature_unit.setter
+    def temperature_unit(self, value):
+        assert isinstance(value, _ureg.Unit), "temperature unit can only be an instance of unit"
+        self._temperature_unit = value
+
+    @property
     def length_unit(self):
         return self._length_unit
+
+    @length_unit.setter
+    def length_unit(self, value):
+        assert isinstance(value, _ureg.Unit), "length unit can only be an instance of unit"
+        self._length_unit = value
 
     @property
     def time_unit(self):
         return self._time_unit
 
+    @time_unit.setter
+    def time_unit(self, value):
+        assert isinstance(value, _ureg.Unit), "time unit can only be an instance of unit"
+        self._time_unit = value
+
     @property
     def energy_unit(self):
         return self._energy_unit
+
+    @energy_unit.setter
+    def energy_unit(self, value):
+        assert isinstance(value, _ureg.Unit), "energy_unit unit can only be an instance of unit"
+        self._energy_unit = value
 
     @property
     def force_constant_unit(self):
@@ -74,6 +110,7 @@ class NoUnitConfiguration(UnitConfiguration):
         super().__init__()
         self._length_unit = 1.
         self._time_unit = 1.
+        self._temperature_unit = 1.
         self._energy_unit = 1.
 
     def convert(self, value, target_units):

--- a/wrappers/python/src/python/readdy/api/conf/UnitConfiguration.py
+++ b/wrappers/python/src/python/readdy/api/conf/UnitConfiguration.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+
+# Copyright © 2016 Computational Molecular Biology Group,
+#                  Freie Universität Berlin (GER)
+#
+# This file is part of ReaDDy.
+#
+# ReaDDy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General
+# Public License along with this program. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""
+Created on 10.10.17
+
+@author: clonker
+"""
+
+from . import ureg as _ureg
+from . import Q_ as _Q_
+
+
+class UnitConfiguration(object):
+    def __init__(self, length_unit='nanometer', time_unit='nanosecond', energy_unit='kilojoule/mol'):
+        self._length_unit = _ureg.parse_units(length_unit)
+        self._time_unit = _ureg.parse_units(time_unit)
+        self._energy_unit = _ureg.parse_units(energy_unit)
+
+    @property
+    def reg(self):
+        return _ureg
+
+    @property
+    def length_unit(self):
+        return self._length_unit
+
+    @property
+    def time_unit(self):
+        return self._time_unit
+
+    @property
+    def energy_unit(self):
+        return self._energy_unit
+
+    @property
+    def force_constant_unit(self):
+        return self.energy_unit / (self.length_unit ** 2)
+
+    @property
+    def diffusion_constant_unit(self):
+        return (self.length_unit ** 2) / self.time_unit
+
+    @property
+    def reaction_rate_unit(self):
+        return 1/self.time_unit
+
+    def convert(self, value, target_units):
+        if not isinstance(value, _Q_):
+            return value
+        return value.to(target_units).magnitude
+
+
+class NoUnitConfiguration(UnitConfiguration):
+    def __init__(self):
+        super().__init__()
+        self._length_unit = 1.
+        self._time_unit = 1.
+        self._energy_unit = 1.
+
+    def convert(self, value, target_units):
+        if not isinstance(value, _Q_):
+            return value
+        return value.magnitude

--- a/wrappers/python/src/python/readdy/api/conf/__init__.py
+++ b/wrappers/python/src/python/readdy/api/conf/__init__.py
@@ -24,3 +24,7 @@ Created on 26.09.17
 
 @author: clonker
 """
+
+from pint import UnitRegistry
+ureg = UnitRegistry()
+Q_ = ureg.Quantity

--- a/wrappers/python/src/python/readdy/api/reaction_diffusion_system.py
+++ b/wrappers/python/src/python/readdy/api/reaction_diffusion_system.py
@@ -152,8 +152,8 @@ class ReactionDiffusionSystem(object):
     @temperature.setter
     def temperature(self, value):
         """
-        Sets the thermal energy of the system.
-        :param value: the new thermal energy [energy]
+        Sets the temperature of the system.
+        :param value: the new temperature [temperature]
         """
         value = self._unit_conf.convert(value, self.temperature_unit)
         if self.temperature_unit != 1:

--- a/wrappers/python/src/python/readdy/api/reaction_diffusion_system.py
+++ b/wrappers/python/src/python/readdy/api/reaction_diffusion_system.py
@@ -152,7 +152,8 @@ class ReactionDiffusionSystem(object):
         The periodic boundary conditions of the system.
 
         If boundaries are set to non-periodic, one has to take care that the particle cannot escape the simulation
-        box, e.g., with a box potential.
+        box, e.g., with a box potential that is inside of the simulation box
+        at least within the directions of non-periodicity.
 
         :return: a list of length 3 containing boolean values indicating whether x-, y-, or z-boundaries are periodic
                  or not

--- a/wrappers/python/src/python/readdy/api/registry/compartments.py
+++ b/wrappers/python/src/python/readdy/api/registry/compartments.py
@@ -29,8 +29,9 @@ Created on 26.09.17
 from readdy.api.utils import vec3_of as _v3_of
 
 class CompartmentRegistry(object):
-    def __init__(self, context_compartments):
+    def __init__(self, context_compartments, units):
         self._compartments = context_compartments
+        self._units = units
 
     def add_sphere(self, conversions, name, origin, radius, larger_or_less=False):
         """
@@ -62,6 +63,8 @@ class CompartmentRegistry(object):
             raise ValueError("radius must be positive")
         if not isinstance(larger_or_less, bool):
             raise ValueError("larger_or_less must be a bool")
+        origin = self._units.convert(origin, self._units.length_unit)
+        radius = self._units.convert(radius, self._units.length_unit)
         self._compartments.add_sphere(conversions, name, _v3_of(origin), radius, larger_or_less)
 
     def add_plane(self, conversions, name, normal_coefficients, distance, larger_or_less=True):
@@ -93,4 +96,6 @@ class CompartmentRegistry(object):
             raise ValueError("distance must be non-negative")
         if not isinstance(larger_or_less, bool):
             raise ValueError("larger_or_less must be a bool")
+        normal_coefficients = self._units.convert(normal_coefficients, self._units.length_unit)
+        distance = self._units.convert(distance, self._units.length_unit)
         self._compartments.add_plane(conversions, name, _v3_of(normal_coefficients), distance, larger_or_less)

--- a/wrappers/python/src/python/readdy/api/registry/observables.py
+++ b/wrappers/python/src/python/readdy/api/registry/observables.py
@@ -61,7 +61,9 @@ class Observables(object):
             types_count_from = [types_count_from]
         if isinstance(types_count_to, str):
             types_count_to = [types_count_to]
-
+        bin_borders = self._simulation._unit_conf.convert(bin_borders, self._simulation.length_unit)
+        particle_to_density = self._simulation._unit_conf.convert(particle_to_density,
+                                                                  1 / self._simulation.length_unit**3)
         assert all([isinstance(x, str) for x in types_count_from]), \
             "types_count_from={} has an invalid type".format(types_count_from)
         assert all([isinstance(x, str) for x in types_count_to]), \

--- a/wrappers/python/src/python/readdy/api/registry/potentials.py
+++ b/wrappers/python/src/python/readdy/api/registry/potentials.py
@@ -29,8 +29,9 @@ import numpy as _np
 from readdy.api.utils import vec3_of as _v3_of
 
 class PotentialRegistry(object):
-    def __init__(self, context_top_registry):
+    def __init__(self, context_top_registry, units):
         self._registry = context_top_registry
+        self._units = units
 
     def add_box(self, particle_type, force_constant, origin, extent):
         """
@@ -39,10 +40,13 @@ class PotentialRegistry(object):
         vertex, respectively.
 
         :param particle_type: the particle type for which the potential is registered
-        :param force_constant: the force constant
-        :param origin: the origin of the box
-        :param extent: the extent of the box
+        :param force_constant: the force constant [energy/length**2]
+        :param origin: the origin of the box [length]
+        :param extent: the extent of the box [length]
         """
+        force_constant = self._units.convert(force_constant, self._units.force_constant_unit)
+        origin = self._units.convert(origin, self._units.length_unit)
+        extent = self._units.convert(extent, self._units.length_unit)
         self._registry.add_box(particle_type, force_constant, _v3_of(origin), _v3_of(extent))
 
     def add_harmonic_repulsion(self, particle_type1, particle_type2, force_constant, interaction_distance):
@@ -53,9 +57,11 @@ class PotentialRegistry(object):
 
         :param particle_type1: first particle type
         :param particle_type2: second particle type
-        :param force_constant: the force constant
-        :param interaction_distance: the interaction distance
+        :param force_constant: the force constant [energy/length**2]
+        :param interaction_distance: the interaction distance [length]
         """
+        force_constant = self._units.convert(force_constant, self._units.force_constant_unit)
+        interaction_distance = self._units.convert(interaction_distance, self._units.length_unit)
         self._registry.add_harmonic_repulsion(particle_type1, particle_type2, force_constant, interaction_distance)
 
     def add_weak_interaction_piecewise_harmonic(self, particle_type1, particle_type2, force_constant, desired_distance,
@@ -68,11 +74,15 @@ class PotentialRegistry(object):
 
         :param particle_type1: first particle type
         :param particle_type2: second particle type
-        :param force_constant: the force constant
-        :param desired_distance: the desired distance, i.e., smallest potential energy
-        :param depth: depth of the potential well
-        :param cutoff: the cutoff radius
+        :param force_constant: the force constant [energy/length**2]
+        :param desired_distance: the desired distance, i.e., smallest potential energy [length]
+        :param depth: depth of the potential well [energy]
+        :param cutoff: the cutoff radius [length]
         """
+        force_constant = self._units.convert(force_constant, self._units.force_constant_unit)
+        desired_distance = self._units.convert(desired_distance, self._units.length_unit)
+        depth = self._units.convert(depth, self._units.energy_unit)
+        cutoff = self._units.convert(cutoff, self._units.length_unit)
         self._registry.add_weak_interaction_piecewise_harmonic(particle_type1, particle_type2, force_constant,
                                                                desired_distance, depth, cutoff)
 
@@ -85,12 +95,15 @@ class PotentialRegistry(object):
         :param particle_type2: second particle type
         :param m: first exponent
         :param n: second exponent
-        :param cutoff: the cutoff radius
+        :param cutoff: the cutoff radius [length]
         :param shift: whether to shift the potential energy
-        :param epsilon: epsilon value
-        :param sigma: sigma value
+        :param epsilon: epsilon value [energy]
+        :param sigma: sigma value [length]
         """
         assert isinstance(shift, bool), "shift can only be bool"
+        cutoff = self._units.convert(cutoff, self._units.length_unit)
+        epsilon = self._units.convert(epsilon, self._units.energy_unit)
+        sigma = self._units.convert(sigma, self._units.length_unit)
         self._registry.add_lennard_jones(particle_type1, particle_type2, m, n, cutoff, shift, epsilon, sigma)
 
     def add_screened_electrostatics(self, particle_type1, particle_type2, electrostatic_strength,
@@ -101,13 +114,19 @@ class PotentialRegistry(object):
 
         :param particle_type1: first particle type
         :param particle_type2: second particle type
-        :param electrostatic_strength: the electrostatic strength
-        :param inverse_screening_depth: the inverse screening depth
-        :param repulsion_strength: the repulsion strength
-        :param repulsion_distance: the repulsion distance
+        :param electrostatic_strength: the electrostatic strength [energy * length]
+        :param inverse_screening_depth: the inverse screening depth [1 / length]
+        :param repulsion_strength: the repulsion strength [energy]
+        :param repulsion_distance: the repulsion distance [length]
         :param exponent: the exponent
-        :param cutoff: the cutoff radius
+        :param cutoff: the cutoff radius [length]
         """
+        electrostatic_strength = self._units.convert(electrostatic_strength,
+                                                     self._units.energy_unit * self._units.length_unit)
+        inverse_screening_depth = self._units.convert(inverse_screening_depth, 1/self._units.length_unit)
+        repulsion_strength = self._units.convert(repulsion_strength, self._units.energy_unit)
+        repulsion_distance = self._units.convert(repulsion_distance, self._units.length_unit)
+        cutoff = self._units.convert(cutoff, self._units.length_unit)
         self._registry.add_screened_electrostatics(particle_type1, particle_type2, electrostatic_strength,
                                                    inverse_screening_depth, repulsion_strength, repulsion_distance,
                                                    exponent, cutoff)
@@ -118,11 +137,14 @@ class PotentialRegistry(object):
         specified sphere.
 
         :param particle_type: the particle type
-        :param force_constant: strength of the potential
-        :param origin: origin of the sphere
-        :param radius: radius of the sphere
+        :param force_constant: strength of the potential [energy/length**2]
+        :param origin: origin of the sphere [length]
+        :param radius: radius of the sphere [length]
         """
         assert radius > 0, "radius has to be positive"
+        force_constant = self._units.convert(force_constant, self._units.force_constant_unit)
+        origin = self._units.convert(origin, self._units.length_unit)
+        radius = self._units.convert(radius, self._units.length_unit)
         self._registry.add_sphere_out(particle_type, force_constant, _v3_of(origin), radius)
 
     def add_sphere_in(self, particle_type, force_constant, origin, radius):
@@ -131,11 +153,14 @@ class PotentialRegistry(object):
         specified sphere.
 
         :param particle_type: the particle type
-        :param force_constant: strength of the potential
-        :param origin: origin of the sphere
-        :param radius: radius of the sphere
+        :param force_constant: strength of the potential [energy/length**2]
+        :param origin: origin of the sphere [length]
+        :param radius: radius of the sphere [length]
         """
         assert radius > 0, "radius has to be positive"
+        force_constant = self._units.convert(force_constant, self._units.force_constant_unit)
+        origin = self._units.convert(origin, self._units.length_unit)
+        radius = self._units.convert(radius, self._units.length_unit)
         self._registry.add_sphere_in(particle_type, force_constant, _v3_of(origin), radius)
 
     def add_spherical_barrier(self, particle_type, height, width, origin, radius):
@@ -146,12 +171,16 @@ class PotentialRegistry(object):
         and differentiable, the force is only continuous and not differentiable.
 
         :param particle_type: the particle type
-        :param height: the height of the barrier
-        :param width: the width of the barrier
-        :param origin: the origin of the sphere
-        :param radius: the radius of the sphere
+        :param height: the height of the barrier [energy]
+        :param width: the width of the barrier [length]
+        :param origin: the origin of the sphere [length]
+        :param radius: the radius of the sphere [length]
         """
         assert radius > 0, "radius has to be positive"
         assert height > 0, "height has to be positive"
         assert width > 0, "width has to be positive"
+        height = self._units.convert(height, self._units.energy_unit)
+        width = self._units.convert(width, self._units.length_unit)
+        origin = self._units.convert(origin, self._units.length_unit)
+        radius = self._units.convert(radius, self._units.length_unit)
         self._registry.add_spherical_barrier(particle_type, height, width, _v3_of(origin), radius)

--- a/wrappers/python/src/python/readdy/api/registry/reactions.py
+++ b/wrappers/python/src/python/readdy/api/registry/reactions.py
@@ -28,8 +28,9 @@ Created on 26.09.17
 
 
 class ReactionRegistry(object):
-    def __init__(self, context_reactions):
+    def __init__(self, context_reactions, units):
         self._reactions = context_reactions
+        self._units = units
 
     def add_decay(self, name, particle_type, rate):
         """
@@ -41,7 +42,7 @@ class ReactionRegistry(object):
 
         :param name: label of the reaction
         :param particle_type: the particle type undergoing the reaction
-        :param rate: microscopic/intrinsic reaction rate constant
+        :param rate: microscopic/intrinsic reaction rate constant [1/time]
         """
         if not isinstance(name, str):
             raise ValueError("name must be a string")
@@ -49,6 +50,7 @@ class ReactionRegistry(object):
             raise ValueError("particle_type must be a string")
         if not rate > 0.:
             raise ValueError("the reaction rate must be positive")
+        rate = self._units.convert(rate, self._units.reaction_rate_unit)
         self._reactions.add_decay(name, particle_type, rate)
 
     def add_conversion(self, name, type_from, type_to, rate):
@@ -62,7 +64,7 @@ class ReactionRegistry(object):
         :param name: label of the reactions
         :param type_from: particle type of educt
         :param type_to: particle type of product
-        :param rate: microscopic/intrinsic reaction rate constant
+        :param rate: microscopic/intrinsic reaction rate constant [1/time]
         """
         if not isinstance(name, str):
             raise ValueError("name must be a string")
@@ -72,6 +74,7 @@ class ReactionRegistry(object):
             raise ValueError("type_to must be a string")
         if not rate > 0.:
             raise ValueError("the reaction rate must be positive")
+        rate = self._units.convert(rate, self._units.reaction_rate_unit)
         self._reactions.add_conversion(name, type_from, type_to, rate)
 
     def add_fusion(self, name, type_from1, type_from2, type_to, rate, educt_distance, weight1=0.5, weight2=0.5):
@@ -90,8 +93,8 @@ class ReactionRegistry(object):
         :param type_from1: particle type of first educt
         :param type_from2: particle type of second educt
         :param type_to: particle type of product
-        :param rate: microscopic/intrinsic reaction rate constant
-        :param educt_distance: maximal distance for the reaction to occur
+        :param rate: microscopic/intrinsic reaction rate constant [1/time]
+        :param educt_distance: maximal distance for the reaction to occur [length]
         :param weight1: value between 0 (product placed at educt1) and 1 (product placed at educt2)
         :param weight2: value between 0 (product placed at educt2) and 1 (product placed at educt1)
         """
@@ -111,6 +114,8 @@ class ReactionRegistry(object):
             raise ValueError("weight1 must be in [0,1]")
         if not 0. <= weight2 <= 1.:
             raise ValueError("weight2 must be in [0,1]")
+        rate = self._units.convert(rate, self._units.reaction_rate_unit)
+        educt_distance = self._units.convert(educt_distance, self._units.length_unit)
         self._reactions.add_fusion(name, type_from1, type_from2, type_to, rate, educt_distance, weight1, weight2)
 
     def add_fission(self, name, type_from, type_to1, type_to2, rate, product_distance, weight1=0.5, weight2=0.5):
@@ -129,8 +134,8 @@ class ReactionRegistry(object):
         :param type_from: particle type of educt
         :param type_to1: particle type of first product
         :param type_to2: particle type of second product
-        :param rate: microscopic/intrinsic reaction rate constant
-        :param product_distance: maximal distance at which products will be placed
+        :param rate: microscopic/intrinsic reaction rate constant [1/time]
+        :param product_distance: maximal distance at which products will be placed [length]
         :param weight1: value between 0 (product1 placed at educt) and 1 (product2 placed at educt)
         :param weight2: value between 0 (product2 placed at educt) and 1 (product1 placed at educt)
         """
@@ -150,6 +155,8 @@ class ReactionRegistry(object):
             raise ValueError("weight1 must be in [0,1]")
         if not 0. <= weight2 <= 1.:
             raise ValueError("weight2 must be in [0,1]")
+        rate = self._units.convert(rate, self._units.reaction_rate_unit)
+        product_distance = self._units.convert(product_distance, self._units.length_unit)
         self._reactions.add_fission(name, type_from, type_to1, type_to2, rate, product_distance, weight1, weight2)
 
     def add_enzymatic(self, name, type_catalyst, type_from, type_to, rate, educt_distance):
@@ -166,8 +173,8 @@ class ReactionRegistry(object):
         :param type_catalyst: particle type of catalyst
         :param type_from: particle type of educt
         :param type_to: particle type of product
-        :param rate: microscopic/intrinsic reaction rate constant
-        :param educt_distance: maximal distance for reaction to occur
+        :param rate: microscopic/intrinsic reaction rate constant [1/time]
+        :param educt_distance: maximal distance for reaction to occur [length]
         """
         if not isinstance(name, str):
             raise ValueError("name must be a string")
@@ -181,11 +188,14 @@ class ReactionRegistry(object):
             raise ValueError("reaction rate must be positive")
         if not educt_distance > 0.:
             raise ValueError("educt_distance must be positive")
+        rate = self._units.convert(rate, self._units.reaction_rate_unit)
+        educt_distance = self._units.convert(educt_distance, self._units.length_unit)
         self._reactions.add_enzymatic(name, type_catalyst, type_from, type_to, rate, educt_distance)
 
     def add(self, descriptor, rate):
         """
-        Register a reaction according to the descriptor string.
+        Register a reaction according to the descriptor string. Note that the reaction radius will be interpreted
+        in default units.
 
         Examples:
             A -> 0
@@ -194,7 +204,8 @@ class ReactionRegistry(object):
             C -> A +(2.0) B [0.5, 0.5]
             A +(2.0) C -> B + C
 
-        :param descriptor: the descriptor string
-        :param rate: microscopic/intrinsic reaction rate constant
+        :param descriptor: the descriptor string, default units
+        :param rate: microscopic/intrinsic reaction rate constant [1/time]
         """
+        rate = self._units.convert(rate, self._units.reaction_rate_unit)
         self._reactions.add(descriptor, rate)

--- a/wrappers/python/src/python/readdy/tests/test_toplevel_api.py
+++ b/wrappers/python/src/python/readdy/tests/test_toplevel_api.py
@@ -39,13 +39,26 @@ class TestTopLevelAPI(ReaDDyTestCase):
     A bunch of sanity checks
     """
 
-    def test_kbt(self):
+    def test_temperature(self):
         rdf = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.])
-        rdf.kbt = 5.
-        np.testing.assert_equal(rdf.kbt, 5. * rdf.energy_unit)
+        rdf.temperature = 293.
+        np.testing.assert_equal(rdf.temperature, 293. * rdf.temperature_unit)
+        np.testing.assert_almost_equal(rdf.kbt.magnitude, (2.4361374086224026 * rdf.energy_unit).magnitude)
+
+    def test_temperature_unitless(self):
+        rdf = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.], unit_system=None)
+        rdf.temperature = 293
+        np.testing.assert_equal(rdf.temperature, 293)
+        np.testing.assert_almost_equal(rdf.kbt, 2.4361374086224026)
+
+    def test_other_units(self):
+        rdf = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.], unit_system={'length_unit': 'kilometer'})
+        rdf = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.], unit_system={'time_unit': 'hour'})
+        rdf = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.], unit_system={'energy_unit': 'kcal/mol'})
+        rdf = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.], unit_system={'temperature_unit': 'rankine'})
 
     def test_box_size(self):
-        rdf = readdy.ReactionDiffusionSystem([1., 2., 3.], length_unit=None, time_unit=None, energy_unit=None)
+        rdf = readdy.ReactionDiffusionSystem([1., 2., 3.], unit_system=None)
         np.testing.assert_equal(rdf.box_size, [1., 2., 3.])
         rdf.box_size = np.array([5., 6., 7.])
         np.testing.assert_equal(rdf.box_size, [5., 6., 7.])

--- a/wrappers/python/src/python/readdy/tests/test_toplevel_registry_compartments.py
+++ b/wrappers/python/src/python/readdy/tests/test_toplevel_registry_compartments.py
@@ -32,7 +32,7 @@ from readdy.util.testing_utils import ReaDDyTestCase
 
 class TestToplevelRegistryCompartments(ReaDDyTestCase):
     def setUp(self):
-        self.rds = ReactionDiffusionSystem()
+        self.rds = ReactionDiffusionSystem(box_size=[1., 1., 1.])
         self.rds.add_species("A", 1.)
         self.rds.add_species("B", 1.)
 

--- a/wrappers/python/src/python/readdy/tests/test_toplevel_registry_reactions.py
+++ b/wrappers/python/src/python/readdy/tests/test_toplevel_registry_reactions.py
@@ -31,7 +31,7 @@ from readdy.util.testing_utils import ReaDDyTestCase
 
 class TestToplevelRegistryReactions(ReaDDyTestCase):
     def setUp(self):
-        self.rds = ReactionDiffusionSystem()
+        self.rds = ReactionDiffusionSystem(box_size=[1., 1., 1.])
         self.rds.add_species("A", 1.)
         self.rds.add_species("B", 1.)
         self.rds.add_species("C", 1.)

--- a/wrappers/python/src/python/readdy/tests/test_units.py
+++ b/wrappers/python/src/python/readdy/tests/test_units.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+
+# Copyright © 2016 Computational Molecular Biology Group,
+#                  Freie Universität Berlin (GER)
+#
+# This file is part of ReaDDy.
+#
+# ReaDDy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General
+# Public License along with this program. If not, see
+# <http://www.gnu.org/licenses/>.
+
+"""
+Created on 10.10.17
+
+@author: clonker
+"""
+
+import readdy
+from readdy.util.testing_utils import ReaDDyTestCase
+
+from readdy.api.conf.UnitConfiguration import UnitConfiguration
+
+import numpy as np
+import pint
+
+class TestUnits(ReaDDyTestCase):
+
+    def test_unit_configuration_sanity(self):
+        conf = UnitConfiguration()
+        reg = pint.UnitRegistry()
+        np.testing.assert_equal(1 * conf.length_unit, 1 * reg.nanometer)
+        np.testing.assert_equal(1 * conf.time_unit, 1 * reg.nanoseconds)
+        np.testing.assert_equal(1 * conf.energy_unit, 1 * reg.kilojoule / reg.mol)
+
+    def test_custom_configuration(self):
+        conf = UnitConfiguration(length_unit='nanometer', time_unit='millisecond', energy_unit='kilocal/mol')
+        a = 1*conf.length_unit
+        b = (1e-6*conf.reg.millimeter).to(conf.length_unit)
+        np.testing.assert_almost_equal(a.magnitude, b.magnitude)
+
+    def test_force_constant_unit(self):
+        conf = UnitConfiguration()
+        kunit = conf.energy_unit / conf.length_unit**2
+        np.testing.assert_equal(kunit, conf.reg.parse_units("kilojoule/(mol * nanometer * nanometer)"))
+
+    def test_box_size(self):
+        sys = readdy.ReactionDiffusionSystem([5,5,5] * readdy.units.meter)
+        np.testing.assert_equal(sys.box_size.magnitude, ([5, 5, 5] * sys.units.meter).to(sys.length_unit).magnitude)
+
+    def test_radians(self):
+        sys = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.])
+        angle = 180 * sys.units.degree
+        np.testing.assert_equal(np.pi, angle.to(sys.units.radians).magnitude)

--- a/wrappers/python/src/python/readdy/tests/test_units.py
+++ b/wrappers/python/src/python/readdy/tests/test_units.py
@@ -61,3 +61,7 @@ class TestUnits(ReaDDyTestCase):
         sys = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.])
         angle = 180 * sys.units.degree
         np.testing.assert_equal(np.pi, angle.to(sys.units.radians).magnitude)
+
+    def test_foo(self):
+        conf = UnitConfiguration()
+        print(conf.reg.boltzmann_constant)

--- a/wrappers/python/src/python/readdy/util/io_utils.py
+++ b/wrappers/python/src/python/readdy/util/io_utils.py
@@ -42,9 +42,10 @@ def get_particle_types(filename, dset_path="readdy/config/particle_types"):
     """
     result = dict()
     with h5py.File(filename, "r") as f:
-        p_types = f[dset_path]
-        for p_type in p_types:
-            result[p_type["name"]] = p_type["type_id"]
+        if dset_path in f:
+            p_types = f[dset_path]
+            for p_type in p_types:
+                result[p_type["name"]] = p_type["type_id"]
     return result
 
 
@@ -58,9 +59,10 @@ def get_particle_types_list(fname, dset_path="readdy/config/particle_types"):
     """
     result = []
     with h5py.File(fname, "r") as f:
-        p_types = f[dset_path]
-        for p_type in p_types:
-            result.append(p_type["name"])
+        if dset_path in f:
+            p_types = f[dset_path]
+            for p_type in p_types:
+                result.append(p_type["name"])
     return result
 
 
@@ -74,9 +76,10 @@ def get_diffusion_constants(filename, dset_path="readdy/config/particle_types"):
     """
     result = dict()
     with h5py.File(filename, "r") as f:
-        p_types = f[dset_path]
-        for p_type in p_types:
-            result[p_type["name"]] = p_type["diffusion_constant"]
+        if dset_path in f:
+            p_types = f[dset_path]
+            for p_type in p_types:
+                result[p_type["name"]] = p_type["diffusion_constant"]
     return result
 
 
@@ -89,7 +92,8 @@ def get_reactions(filename, dset_path="readdy/config/registered_reactions"):
     """
     result = dict()
     with h5py.File(filename, "r") as f:
-        reactions = f[dset_path]
-        for r in reactions:
-            result[r["name"]] = np.copy(r)
+        if dset_path in f:
+            reactions = f[dset_path]
+            for r in reactions:
+                result[r["name"]] = np.copy(r)
     return result


### PR DESCRIPTION
### Units
Introduced a runtime dependency to [pint](https://pint.readthedocs.io/). Units can now be used in all relevant api functions:

--- 
Construct a system with a simulation box size of (10, 10, 10) and units of:
    - length in nanometers
    - time in nanoseconds
    - energy in kJ/mol
The temperature is defaulted to 2.437 kJ/mol, all boundaries are set to be periodic.
```python
import readdy
system = readdy.ReactionDiffusionSystem([10., 10., 10.])
```
The simulation box size is the only required constructor argument of a reaction diffusion system.

---
Construct a system with a simulation box size of (10, 10, 10) and units of:
    - length in kilometers
    - time in hours
    - energy in kcal/mol
```python
import readdy
system = readdy.ReactionDiffusionSystem([10, 10, 10] * readdy.units.meters,
            length_unit='kilometer', time_unit='hour', energy_unit='kilocal/mol')
print(system.box_size)
>>> [ 0.01  0.01  0.01] kilometer
print(system.kbt)
>>> 0.5824569789674953 kilocalorie / mole
```
The room temperature as well as any other units of time/length/energy will be automatically converted to this particular set of system units.

---
Construct a unitless system with a simulation box size of (10, 10, 10):
```python
import readdy
system = readdy.ReactionDiffusionSystem([10, 10, 10], length_unit=None, time_unit=None,
            energy_unit=None)
print(system.box_size)
>>> [ 10.  10.  10.]
print(system.kbt)
>>> 2.437
```
If time, length, and energy units are set to None or empty strings, the system will be treated as completely unitless system.

---
If properties are set without providing a particular unit, e.g., 
```python
system.potentials.add_harmonic_repulsion("A", "B", force_constant=10., 
    interaction_distance=5.)
```

the system's units are assumed without further conversion, i.e., `energy/length**2` for the force constant, and `length` for the interaction distance. Providing a unit will trigger a conversion:
```python
from readdy import units as units
sys = readdy.ReactionDiffusionSystem(box_size=[1., 1., 1.])
sys.add_species("A", 1.)
sys.add_species("B", 1.)
sys.potentials.add_harmonic_repulsion("A", "B", 
    force_constant=10. * units.kilocal / (units.mol * units.mile**2), 
    interaction_distance=5.)
```
or also trigger an error if the dimensionality does not match:
```python
sys.potentials.add_harmonic_repulsion("A", "B", 
    force_constant=10. * units.kilocal / (units.mol * units.mile**3), 
    interaction_distance=5.)
```
raises an
```
DimensionalityError: Cannot convert from 'kilocalorie / mile ** 3 / mole' ([mass] / [length] / [substance] / [time] ** 2) to 'kilojoule / mole / nanometer ** 2' ([mass] / [substance] / [time] ** 2)
```

### PBC and box potentials
Upon simulation start there will be a check on the particle types together with periodicity of the simulation box and box potentials, in particular:

If the simulation box is not completely periodic and if the particle types in that box have no box potential to keep them contained in the non-periodic directions, i.e.,
```
box_lower_left[dim] >= potential_lower_left[dim] 
    or box_upper_right[dim] <= potential_upper_right[dim] 
```
is `true` for any non-periodic `dim`, an exception is thrown.