### PR TITLE
Fix performReaction near periodic boundaries

### DIFF
--- a/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/reactions/ReactionUtils.h
@@ -133,6 +133,7 @@ void performReaction(data_t* data, const readdy::model::Context& context, data_t
                      data_t::EntriesUpdate& newEntries, std::vector<data_t::size_type>& decayedEntries,
                      Reaction* reaction, record_t* record) {
     const auto& pbc = context.applyPBCFun();
+    const auto &shortestDifferenceFun = context.shortestDifferenceFun();
     auto& entry1 = data->entry_at(idx1);
     auto& entry2 = data->entry_at(idx2);
     if(record) {
@@ -190,11 +191,12 @@ void performReaction(data_t* data, const readdy::model::Context& context, data_t
         case reaction_type::Fusion: {
             const auto& e1Pos = entry1.pos;
             const auto& e2Pos = entry2.pos;
+            const auto difference = shortestDifferenceFun(e1Pos, e2Pos);
             if (reaction->educts()[0] == entry1.type) {
-                newEntries.emplace_back(pbc(entry1.pos + reaction->weight1() * (e2Pos - e1Pos)),
+                newEntries.emplace_back(pbc(entry1.pos + reaction->weight1() * difference),
                                         reaction->products()[0], readdy::model::Particle::nextId());
             } else {
-                newEntries.emplace_back(pbc(entry1.pos + reaction->weight2() * (e2Pos - e1Pos)),
+                newEntries.emplace_back(pbc(entry1.pos + reaction->weight2() * difference),
                                         reaction->products()[0], readdy::model::Particle::nextId());
             }
             decayedEntries.push_back(idx1);

--- a/kernels/singlecpu/src/actions/SCPUReactionImpls.cpp
+++ b/kernels/singlecpu/src/actions/SCPUReactionImpls.cpp
@@ -129,7 +129,6 @@ std::vector<event_t> findEvents(const SCPUKernel *const kernel, scalar dt, bool 
 void SCPUUncontrolledApproximation::perform(const util::PerformanceNode &node) {
     auto t = node.timeit();
     const auto &ctx = kernel->context();
-    const auto &fixPos = ctx.fixPositionFun();
     SCPUStateModel &stateModel = kernel->getSCPUKernelStateModel();
     if(ctx.recordReactionsWithPositions()) {
         stateModel.reactionRecords().clear();
@@ -159,10 +158,10 @@ void SCPUUncontrolledApproximation::perform(const util::PerformanceNode &node) {
                     if(ctx.recordReactionsWithPositions()) {
                         reaction_record record;
                         record.id = reaction->id();
-                        performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, fixPos, &record);
+                        performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, ctx, &record);
                         stateModel.reactionRecords().push_back(record);
                     } else {
-                        performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, fixPos, nullptr);
+                        performReaction(data, entry1, entry1, newParticles, decayedEntries, reaction, ctx, nullptr);
                     }
                     for (auto _it2 = it + 1; _it2 != events.end(); ++_it2) {
                         if (_it2->idx1 == entry1 || _it2->idx2 == entry1) {
@@ -174,10 +173,10 @@ void SCPUUncontrolledApproximation::perform(const util::PerformanceNode &node) {
                     if(ctx.recordReactionsWithPositions()) {
                         reaction_record record;
                         record.id = reaction->id();
-                        performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, &record);
+                        performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, ctx, &record);
                         stateModel.reactionRecords().push_back(record);
                     } else {
-                        performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, nullptr);
+                        performReaction(data, entry1, event.idx2, newParticles, decayedEntries, reaction, ctx, nullptr);
                     }
                     for (auto _it2 = it + 1; _it2 != events.end(); ++_it2) {
                         if (_it2->idx1 == entry1 || _it2->idx2 == entry1 ||
@@ -271,7 +270,6 @@ scpu_data::entries_update handleEventsGillespie(
 
     if (!events.empty()) {
         const auto &ctx = kernel->context();
-        const auto &fixPos = ctx.fixPositionFun();
         auto &model = kernel->getSCPUKernelStateModel();
         const auto data = kernel->getSCPUKernelStateModel().getParticleData();
         /**
@@ -304,11 +302,11 @@ scpu_data::entries_update handleEventsGillespie(
                             if(ctx.recordReactionsWithPositions()) {
                                 reaction_record record;
                                 record.id = reaction->id();
-                                performReaction(*data, entry1, entry1, newParticles, decayedEntries, reaction, fixPos,
+                                performReaction(*data, entry1, entry1, newParticles, decayedEntries, reaction, ctx,
                                                 &record);
                                 model.reactionRecords().push_back(record);
                             } else {
-                                performReaction(*data, entry1, entry1, newParticles, decayedEntries, reaction, fixPos,
+                                performReaction(*data, entry1, entry1, newParticles, decayedEntries, reaction, ctx,
                                                 nullptr);
                             }
                             if(ctx.recordReactionCounts()) {
@@ -319,10 +317,10 @@ scpu_data::entries_update handleEventsGillespie(
                             if(ctx.recordReactionsWithPositions()) {
                                 reaction_record record;
                                 record.id = reaction->id();
-                                performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, &record);
+                                performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction, ctx, &record);
                                 model.reactionRecords().push_back(record);
                             } else {
-                                performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction, fixPos, nullptr);
+                                performReaction(*data, entry1, event.idx2, newParticles, decayedEntries, reaction, ctx, nullptr);
                             }
                             if(ctx.recordReactionCounts()) {
                                 model.reactionCounts().at(reaction->id())++;


### PR DESCRIPTION
- correct position of reaction products in Fission, that would otherwise end up outside of the box
- new position of Fusion product is calculated with minimum-image difference vector, a Fusion product might otherwise end up in the middle of the box, if both educts were to reaction "through the boundary"