### PR TITLE
fix spatial topology reactions with self

### DIFF
--- a/kernels/cpu/src/actions/CPUEvaluateTopologyReactions.cpp
+++ b/kernels/cpu/src/actions/CPUEvaluateTopologyReactions.cpp
@@ -378,6 +378,13 @@ void CPUEvaluateTopologyReactions::handleTopologyTopologyReaction(CPUStateModel:
             // introduce edge if not already present
             auto v1 = t1->vertexForParticle(event.idx1);
             auto v2 = t1->vertexForParticle(event.idx2);
+            if(entry1Type == reaction.type1() && t1->type() == reaction.top_type1()) {
+                v1->setParticleType(reaction.type_to1());
+                v2->setParticleType(reaction.type_to2());
+            } else {
+                v1->setParticleType(reaction.type_to2());
+                v2->setParticleType(reaction.type_to1());
+            }
             if(!t1->graph().containsEdge(v1, v2)) {
                 t1->graph().addEdge(v1, v2);
             }

--- a/kernels/singlecpu/src/actions/SCPUEvaluateTopologyReactions.cpp
+++ b/kernels/singlecpu/src/actions/SCPUEvaluateTopologyReactions.cpp
@@ -308,9 +308,17 @@ void SCPUEvaluateTopologyReactions::handleTopologyTopologyReaction(SCPUStateMode
             // introduce edge if not already present
             auto v1 = t1->vertexForParticle(event.idx1);
             auto v2 = t1->vertexForParticle(event.idx2);
+            if(entry1Type == reaction.type1() && t1->type() == reaction.top_type1()) {
+                v1->setParticleType(reaction.type_to1());
+                v2->setParticleType(reaction.type_to2());
+            } else {
+                v1->setParticleType(reaction.type_to2());
+                v2->setParticleType(reaction.type_to1());
+            }
             if(!t1->graph().containsEdge(v1, v2)) {
                 t1->graph().addEdge(v1, v2);
             }
+
         } else {
             // merge topologies
             for(auto pidx : t2->getParticles()) {

--- a/readdy/main/model/topologies/GraphTopology.cpp
+++ b/readdy/main/model/topologies/GraphTopology.cpp
@@ -95,7 +95,7 @@ void GraphTopology::configure() {
 
             ss << "The edge " << v1->particleIndex;
             ss << " -- " << v2->particleIndex;
-            ss << " has no bond configured! (See Context.configure_bond_potential())";
+            ss << " has no bond configured!";
 
             throw std::invalid_argument(ss.str());
         }

--- a/tools/ci/travis/install_miniconda.sh
+++ b/tools/ci/travis/install_miniconda.sh
@@ -20,4 +20,4 @@ export PATH=$TARGET/bin:$PATH
 
 conda config --set always_yes true
 #conda update --all
-conda install -q conda-build=3.5.1
+conda install -q conda-build

--- a/tools/conda-recipe/build.sh
+++ b/tools/conda-recipe/build.sh
@@ -63,7 +63,7 @@ err_code=0
 ret_code=0
 
 echo "calling c++ core unit tests"
-bin/runUnitTests
+CONDA_ENV_PATH=${PREFIX} bin/runUnitTests
 err_code=$?
 if [ ${err_code} -ne 0 ]; then
     ret_code=${err_code}
@@ -71,7 +71,7 @@ if [ ${err_code} -ne 0 ]; then
 fi
 
 echo "calling c++ singlecpu unit tests"
-bin/runUnitTests_singlecpu
+CONDA_ENV_PATH=${PREFIX} bin/runUnitTests_singlecpu
 err_code=$?
 if [ ${err_code} -ne 0 ]; then
     ret_code=${err_code}
@@ -79,7 +79,7 @@ if [ ${err_code} -ne 0 ]; then
 fi
 
 echo "calling c++ cpu unit tests"
-bin/runUnitTests_cpu
+CONDA_ENV_PATH=${PREFIX} bin/runUnitTests_cpu
 err_code=$?
 if [ ${err_code} -ne 0 ]; then
     ret_code=${err_code}


### PR DESCRIPTION
- fix for spatial topology reactions where particles of one and the same topology "react" with one another, i.e., form a bond. in such a case the target types were not handeled properly
- also update build script so that we can unpin the conda-build version