### PR TITLE
Update periodic boundary condition handling

### DIFF
--- a/include/readdy/common/Vec3Tensor.h
+++ b/include/readdy/common/Vec3Tensor.h
@@ -35,6 +35,7 @@
 #include <cassert>
 #include "readdy/common/macros.h"
 #include "ReaDDyVec3.h"
+#include "common.h"
 
 NAMESPACE_BEGIN(readdy)
 NAMESPACE_BEGIN(model)

--- a/include/readdy/common/numeric.h
+++ b/include/readdy/common/numeric.h
@@ -33,13 +33,11 @@
 
 #include <type_traits>
 
-#include "common.h"
-#include "ReaDDyVec3.h"
+namespace readdy {
+namespace util {
+namespace numeric {
 
-NAMESPACE_BEGIN(readdy)
-NAMESPACE_BEGIN(util)
-NAMESPACE_BEGIN(numeric)
-
+template<typename scalar>
 inline constexpr scalar pi() { return 3.141592653589793238462643383279502884e+00; }
 
 template<typename T, typename D, typename std::enable_if<
@@ -65,20 +63,18 @@ template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>:
 constexpr T clamp_min(T d, T min) {
     return d < min ? min : d;
 }
-
-NAMESPACE_END(numeric)
-NAMESPACE_END(util)
-
-NAMESPACE_BEGIN(math)
-
+}
+}
+namespace math {
+template<typename Matrix33, typename Vec3>
 inline Matrix33 outerProduct(const Vec3 &lhs, const Vec3 &rhs) {
-    Matrix33::data_arr result;
-    for(Matrix33::size_type i = 0; i < Matrix33::n(); ++i) {
-        for(Matrix33::size_type j = 0; j < Matrix33::m(); ++j) {
+    typename Matrix33::data_arr result;
+    for(typename Matrix33::size_type i = 0; i < Matrix33::n(); ++i) {
+        for(typename Matrix33::size_type j = 0; j < Matrix33::m(); ++j) {
             result.at(Matrix33::m()*j+i) = lhs[j]*rhs[i];
         }
     }
     return Matrix33(result);
 }
-NAMESPACE_END(math)
-NAMESPACE_END(readdy)
+}
+}

--- a/include/readdy/kernel/singlecpu/model/topologies/SCPUTopologyActions.h
+++ b/include/readdy/kernel/singlecpu/model/topologies/SCPUTopologyActions.h
@@ -38,6 +38,7 @@
 #include <readdy/model/topologies/potentials/TopologyPotentialActions.h>
 #include <readdy/kernel/singlecpu/SCPUStateModel.h>
 #include <readdy/model/topologies/Topology.h>
+#include <readdy/common/boundary_condition_operations.h>
 
 NAMESPACE_BEGIN(readdy)
 NAMESPACE_BEGIN(kernel)
@@ -61,12 +62,12 @@ public:
     scalar perform(const readdy::model::top::Topology* const topology) override {
         scalar energy = 0;
         const auto &particleIndices = topology->getParticles();
-        const auto &d = context->shortestDifferenceFun();
         for (const auto &bond : potential->getBonds()) {
             Vec3 forceUpdate{0, 0, 0};
             auto &e1 = data->entry_at(particleIndices.at(bond.idx1));
             auto &e2 = data->entry_at(particleIndices.at(bond.idx2));
-            const auto x_ij = d(e1.position(), e2.position());
+            const auto x_ij = bcs::shortestDifference(e1.position(), e2.position(), context->boxSize().data(),
+                                                      context->periodicBoundaryConditions().data());
             potential->calculateForce(forceUpdate, x_ij, bond);
             e1.force += forceUpdate;
             e2.force -= forceUpdate;
@@ -90,15 +91,15 @@ public:
     scalar perform(const readdy::model::top::Topology* const topology) override {
         scalar energy = 0;
         const auto &particleIndices = topology->getParticles();
-        const auto &d = context->shortestDifferenceFun();
-
 
         for (const auto &angle : potential->getAngles()) {
             auto &e1 = data->entry_at(particleIndices.at(angle.idx1));
             auto &e2 = data->entry_at(particleIndices.at(angle.idx2));
             auto &e3 = data->entry_at(particleIndices.at(angle.idx3));
-            const auto x_ji = d(e2.pos, e1.pos);
-            const auto x_jk = d(e2.pos, e3.pos);
+            const auto x_ji = bcs::shortestDifference(e2.pos, e1.pos, context->boxSize().data(),
+                                                      context->periodicBoundaryConditions().data());
+            const auto x_jk = bcs::shortestDifference(e2.pos, e3.pos, context->boxSize().data(),
+                                                      context->periodicBoundaryConditions().data());
             energy += potential->calculateEnergy(x_ji, x_jk, angle);
             potential->calculateForce(e1.force, e2.force, e3.force, x_ji, x_jk, angle);
         }
@@ -119,16 +120,18 @@ public:
     scalar perform(const readdy::model::top::Topology* const topology) override {
         scalar energy = 0;
         const auto &particleIndices = topology->getParticles();
-        const auto &d = context->shortestDifferenceFun();
 
         for (const auto &dih : potential->getDihedrals()) {
             auto &e_i = data->entry_at(particleIndices.at(dih.idx1));
             auto &e_j = data->entry_at(particleIndices.at(dih.idx2));
             auto &e_k = data->entry_at(particleIndices.at(dih.idx3));
             auto &e_l = data->entry_at(particleIndices.at(dih.idx4));
-            const auto x_ji = d(e_j.pos, e_i.pos);
-            const auto x_kj = d(e_k.pos, e_j.pos);
-            const auto x_kl = d(e_k.pos, e_l.pos);
+            const auto x_ji = bcs::shortestDifference(e_j.pos, e_i.pos, context->boxSize().data(),
+                                                      context->periodicBoundaryConditions().data());
+            const auto x_kj = bcs::shortestDifference(e_k.pos, e_j.pos, context->boxSize().data(),
+                                                      context->periodicBoundaryConditions().data());
+            const auto x_kl = bcs::shortestDifference(e_k.pos, e_l.pos, context->boxSize().data(),
+                                                      context->periodicBoundaryConditions().data());
             energy += potential->calculateEnergy(x_ji, x_kj, x_kl, dih);
             potential->calculateForce(e_i.force, e_j.force, e_k.force, e_l.force, x_ji, x_kj, x_kl, dih);
         }

--- a/include/readdy/model/Context.h
+++ b/include/readdy/model/Context.h
@@ -102,22 +102,6 @@ public:
         return std::make_tuple(lowerLeft, upperRight);
     };
 
-    const fix_pos_fun &fixPositionFun() const {
-        return _fixPositionFun;
-    }
-
-    const dist_squared_fun &distSquaredFun() const {
-        return _distFun;
-    }
-
-    const shortest_dist_fun &shortestDifferenceFun() const {
-        return _diffFun;
-    }
-
-    const pbc_fun &applyPBCFun() const {
-        return _pbc;
-    }
-
     const scalar calculateMaxCutoff() const;
 
     compartments::CompartmentRegistry &compartments() {
@@ -247,8 +231,6 @@ public:
     Context &operator=(const Context &rhs) = default;
 
 private:
-    void updateFunctions();
-
     ParticleTypeRegistry _particleTypeRegistry;
     reactions::ReactionRegistry _reactionRegistry;
     potentials::PotentialRegistry _potentialRegistry;
@@ -260,11 +242,6 @@ private:
     scalar _kBT{1};
     BoxSize _box_size{{1, 1, 1}};
     PeriodicBoundaryConditions _periodic_boundary{{true, true, true}};
-
-    std::function<Vec3(const Vec3 &)> _pbc;
-    std::function<void(Vec3 &)> _fixPositionFun;
-    std::function<Vec3(const Vec3 &, const Vec3 &)> _diffFun;
-    std::function<scalar(const Vec3 &, const Vec3 &)> _distFun;
 
     // here come horrible flags
     bool _recordReactionsWithPositions{false};

--- a/include/readdy/model/observables/RadialDistribution.h
+++ b/include/readdy/model/observables/RadialDistribution.h
@@ -43,15 +43,15 @@ NAMESPACE_BEGIN(observables)
 
 class RadialDistribution : public Observable<std::pair<std::vector<scalar>, std::vector<scalar>>> {
 public:
-    RadialDistribution(Kernel *const kernel, stride_type stride, std::vector<scalar> binBorders,
+    RadialDistribution(Kernel *kernel, stride_type stride, std::vector<scalar> binBorders,
                        std::vector<particle_type_type> typeCountFrom, std::vector<particle_type_type> typeCountTo,
                        scalar particleToDensity);
 
-    RadialDistribution(Kernel *const kernel, stride_type stride, const std::vector<scalar> &binBorders,
+    RadialDistribution(Kernel *kernel, stride_type stride, const std::vector<scalar> &binBorders,
                        const std::vector<std::string> &typeCountFrom, const std::vector<std::string> &typeCountTo,
                        scalar particleToDensity);
 
-    virtual ~RadialDistribution();
+    ~RadialDistribution() override;
 
     const std::vector<scalar> &getBinBorders() const;
 

--- a/include/readdy/model/topologies/potentials/TorsionPotential.h
+++ b/include/readdy/model/topologies/potentials/TorsionPotential.h
@@ -53,7 +53,8 @@ struct DihedralConfiguration {
     DihedralConfiguration(size_t idx1, size_t idx2, size_t idx3, size_t idx4, scalar forceConstant, scalar multiplicity,
              scalar equilibriumAngle)   : idx1(idx1), idx2(idx2), idx3(idx3), idx4(idx4), forceConstant(forceConstant),
                                           phi_0(equilibriumAngle), multiplicity(multiplicity) {
-        if (equilibriumAngle > readdy::util::numeric::pi() || equilibriumAngle < -readdy::util::numeric::pi()) {
+        if (equilibriumAngle > readdy::util::numeric::pi<scalar>()
+                || equilibriumAngle < -readdy::util::numeric::pi<scalar>()) {
             throw std::invalid_argument("the equilibrium angle should be within [-pi, pi], but was "
                                         + std::to_string(equilibriumAngle));
         }

--- a/include/readdy/model/topologies/reactions/Recipe.h
+++ b/include/readdy/model/topologies/reactions/Recipe.h
@@ -94,7 +94,7 @@ public:
 
     Recipe &separateVertex(const vertex_ref &vertex) {
         std::for_each(vertex->neighbors().begin(), vertex->neighbors().end(), [this, &vertex](const auto &neighbor) {
-            removeEdge(std::make_tuple(vertex, neighbor));
+            this->removeEdge(std::make_tuple(vertex, neighbor));
         });
         return *this;
     }

--- a/kernels/cpu/include/readdy/kernel/cpu/actions/CPUCalculateForces.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/CPUCalculateForces.h
@@ -56,7 +56,7 @@ protected:
                                  const CPUStateModel::neighbor_list &nl, std::promise<scalar> &energyPromise,
                                  std::promise<Matrix33> &virialPromise,
                                  model::potentials::PotentialRegistry::potential_o2_registry pot2,
-                                 model::Context::shortest_dist_fun d);
+                                 model::Context::BoxSize box, model::Context::PeriodicBoundaryConditions pbc);
 
     static void calculate_topologies(std::size_t /*tid*/, top_bounds topBounds, model::top::TopologyActionFactory *taf,
                                      std::promise<scalar> &energyPromise);
@@ -64,8 +64,7 @@ protected:
 
     static void calculate_order1(std::size_t /*tid*/, data_bounds dataBounds,
                                  std::promise<scalar> &energyPromise, CPUStateModel::data_type *data,
-                                 model::potentials::PotentialRegistry::potential_o1_registry pot1,
-                                 model::Context::shortest_dist_fun d);
+                                 model::potentials::PotentialRegistry::potential_o1_registry pot1);
 
     CPUKernel *const kernel;
 };

--- a/kernels/cpu/include/readdy/kernel/cpu/data/DefaultDataContainer.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/data/DefaultDataContainer.h
@@ -35,6 +35,7 @@
 #include <readdy/model/Particle.h>
 #include <hilbert.h>
 #include <readdy/kernel/cpu/pool.h>
+#include <readdy/common/boundary_condition_operations.h>
 #include "DataContainer.h"
 
 namespace readdy {
@@ -128,7 +129,8 @@ public:
     void displace(size_type index, const Particle::pos_type &delta) override {
         auto &entry = _entries.at(index);
         entry.pos += delta;
-        _context.get().fixPositionFun()(entry.pos);
+        bcs::fixPosition(entry.pos, _context.get().boxSize().data(),
+                         _context.get().periodicBoundaryConditions().data());
     };
 
     void hilbertSort(scalar gridWidth) {

--- a/kernels/cpu/src/actions/CPUEvaluateTopologyReactions.cpp
+++ b/kernels/cpu/src/actions/CPUEvaluateTopologyReactions.cpp
@@ -213,7 +213,8 @@ CPUEvaluateTopologyReactions::topology_reaction_events CPUEvaluateTopologyReacti
         if (!context.topology_registry().spatialReactionRegistry().empty()) {
             const auto &model = kernel->getCPUKernelStateModel();
             const auto &top_registry = context.topology_registry();
-            const auto &d2 = context.distSquaredFun();
+            const auto &box = context.boxSize().data();
+            const auto &pbc = context.periodicBoundaryConditions().data();
             const auto &data = *kernel->getCPUKernelStateModel().getParticleData();
             const auto &nl = *kernel->getCPUKernelStateModel().getNeighborList();
             const auto &topologies = kernel->getCPUKernelStateModel().topologies();
@@ -240,7 +241,7 @@ CPUEvaluateTopologyReactions::topology_reaction_events CPUEvaluateTopologyReacti
                                     static_cast<std::size_t>(neighbor.topology_index))->type()
                                                                     : static_cast<topology_type_type>(-1);
 
-                            const auto distSquared = d2(entry.pos, neighbor.pos);
+                            const auto distSquared = bcs::distSquared(entry.pos, neighbor.pos, box, pbc);
                             std::size_t reaction_index = 0;
                             const auto &otherTop = hasNeighborTop ? model.topologies().at(
                                     static_cast<std::size_t>(neighbor.topology_index)

--- a/kernels/cpu/src/actions/reactions/CPUGillespie.cpp
+++ b/kernels/cpu/src/actions/reactions/CPUGillespie.cpp
@@ -47,8 +47,6 @@ void CPUGillespie::perform(const util::PerformanceNode &node) {
     }
     auto &stateModel = kernel->getCPUKernelStateModel();
     auto data = stateModel.getParticleData();
-    const auto &dist = ctx.distSquaredFun();
-    const auto &fixPos = ctx.fixPositionFun();
     const auto nl = stateModel.getNeighborList();
 
     if(ctx.recordReactionCounts()) {
@@ -57,7 +55,7 @@ void CPUGillespie::perform(const util::PerformanceNode &node) {
 
     scalar alpha = 0.0;
     std::vector<event_t> events;
-    gatherEvents(kernel, readdy::util::range<event_t::index_type>(0, data->size()), nl, data, alpha, events, dist);
+    gatherEvents(kernel, readdy::util::range<event_t::index_type>(0, data->size()), nl, data, alpha, events);
     if(ctx.recordReactionsWithPositions()) {
         stateModel.reactionRecords().clear();
         if(ctx.recordReactionCounts()) {

--- a/kernels/cpu/src/actions/reactions/ReactionUtils.cpp
+++ b/kernels/cpu/src/actions/reactions/ReactionUtils.cpp
@@ -43,7 +43,8 @@ data_t::DataUpdate handleEventsGillespie(
         CPUKernel *const kernel, scalar timeStep, bool filterEventsInAdvance, bool approximateRate,
         std::vector<event_t> &&events, std::vector<record_t> *maybeRecords, reaction_counts_map *maybeCounts) {
     using rdy_particle_t = readdy::model::Particle;
-    const auto &fixPos = kernel->context().fixPositionFun();
+    const auto &box = kernel->context().boxSize().data();
+    const auto &pbc = kernel->context().periodicBoundaryConditions().data();
 
     data_t::EntriesUpdate newParticles{};
     std::vector<data_t::size_type> decayedEntries{};
@@ -73,7 +74,7 @@ data_t::DataUpdate handleEventsGillespie(
                         record_t record;
                         record.id = reaction->id();
                         performReaction(data, ctx, entry1, entry1, newParticles, decayedEntries, reaction, &record);
-                        fixPos(record.where);
+                        bcs::fixPosition(record.where, box, pbc);
                         maybeRecords->push_back(record);
                     } else {
                         performReaction(data, ctx, entry1, entry1, newParticles, decayedEntries, reaction, nullptr);
@@ -89,7 +90,7 @@ data_t::DataUpdate handleEventsGillespie(
                         record.id = reaction->id();
                         performReaction(data, ctx, entry1, event.idx2, newParticles, decayedEntries, reaction,
                                         &record);
-                        fixPos(record.where);
+                        bcs::fixPosition(record.where, box, pbc);
                         maybeRecords->push_back(record);
                     } else {
                         performReaction(data, ctx, entry1, event.idx2, newParticles, decayedEntries, reaction,

--- a/kernels/cpu/src/observables/CPUObservableFactory.cpp
+++ b/kernels/cpu/src/observables/CPUObservableFactory.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<model::observables::RadialDistribution>
 CPUObservableFactory::radialDistribution(stride_type stride, std::vector<scalar> binBorders,
                                          std::vector<std::string> typeCountFrom, std::vector<std::string> typeCountTo,
                                          scalar particleDensity) const {
-    return {std::make_unique<readdy::kernel::scpu::observables::SCPURadialDistribution<CPUKernel>>(
+    return {std::make_unique<model::observables::RadialDistribution>(
             kernel, stride, binBorders, typeCountFrom, typeCountTo, particleDensity
     )};
 }

--- a/kernels/cpu/test/TestCellLinkedList.cpp
+++ b/kernels/cpu/test/TestCellLinkedList.cpp
@@ -54,8 +54,6 @@ void insertTestImpl(readdy::kernel::cpu::data::DefaultDataContainer &data, readd
                     readdy::kernel::cpu::thread_pool &pool, std::uint8_t radius) {
     using namespace readdy;
 
-    const auto &d2 = context.distSquaredFun();
-
     std::vector<model::Particle::id_type> particleIds;
     std::for_each(data.begin(), data.end(), [&] (const auto &entry){ particleIds.push_back(entry.id); });
     scalar cutoff = 1;
@@ -91,7 +89,7 @@ void insertTestImpl(readdy::kernel::cpu::data::DefaultDataContainer &data, readd
 
             std::size_t pidx = 0;
             for (const auto &e : data) {
-                if (pidx != *itParticle && d2(entry.pos, e.pos) < cutoff * cutoff) {
+                if (pidx != *itParticle && bcs::dist(entry.pos, e.pos, context.boxSize(), context.periodicBoundaryConditions()) < cutoff) {
                     ASSERT_TRUE(std::find(neighbors.begin(), neighbors.end(), pidx) != neighbors.end());
                 }
                 ++pidx;
@@ -177,8 +175,6 @@ void insertAndDearviateTestImpl(std::uint8_t radius) {
 
     context.configure();
 
-    const auto &d2 = context.distSquaredFun();
-
     CLL nl(data, context, pool);
     nl.setUp(0, radius, {});
     nl.update({});
@@ -199,7 +195,7 @@ void insertAndDearviateTestImpl(std::uint8_t radius) {
             std::size_t pidx = 0;
             for (const auto &e : nl.data()) {
                 if (!e.deactivated) {
-                    if (pidx != *itParticle && d2(entry.pos, e.pos) < cutoff * cutoff) {
+                    if (pidx != *itParticle && bcs::dist(entry.pos, e.pos, context.boxSize(), context.periodicBoundaryConditions()) < cutoff) {
                         ASSERT_TRUE(std::find(neighbors.begin(), neighbors.end(), pidx) != neighbors.end());
                     }
                 }
@@ -265,7 +261,6 @@ void diffuseTestImpl(std::uint8_t radius) {
 
         nl.update({});
 
-        const auto &d2 = context.distSquaredFun();
 
         for(std::size_t cell = 0; cell < nl.nCells(); ++cell) {
             for(auto itParticle = nl.particlesBegin(cell); itParticle != nl.particlesEnd(cell); ++itParticle) {
@@ -282,7 +277,7 @@ void diffuseTestImpl(std::uint8_t radius) {
                 std::size_t pidx = 0;
                 for (const auto &e : nl.data()) {
                     if (!e.deactivated) {
-                        if (pidx != *itParticle && d2(entry.pos, e.pos) < cutoff * cutoff) {
+                        if (pidx != *itParticle && bcs::dist(entry.pos, e.pos, context.boxSize(), context.periodicBoundaryConditions()) < cutoff) {
                             ASSERT_NE(std::find(neighbors.begin(), neighbors.end(), pidx), neighbors.end());
                         }
                     }

--- a/kernels/cpu/test/TestReactions.cpp
+++ b/kernels/cpu/test/TestReactions.cpp
@@ -71,7 +71,6 @@ TEST(CPUTestReactions, CheckInOutTypesAndPositions) {
     auto kernel = std::make_unique<readdy::kernel::cpu::CPUKernel>();
     kernel->context().periodicBoundaryConditions() = {{false, false, false}};
     kernel->context().boxSize() = {{100, 100, 100}};
-    const auto diff = kernel->context().shortestDifferenceFun();
     kernel->context().particle_types().add("A", .1); // type id 0
     kernel->context().particle_types().add("B", .1); // type id 1
     kernel->context().particle_types().add("C", .1); // type id 2
@@ -137,7 +136,8 @@ TEST(CPUTestReactions, CheckInOutTypesAndPositions) {
 
         EXPECT_EQ(data.entry_at(0).type, fission.getTo1());
         EXPECT_EQ(data.entry_at(1).type, fission.getTo2());
-        auto p_12 = diff(data.pos(0), data.pos(1));
+        auto p_12 = readdy::bcs::shortestDifference(data.pos(0), data.pos(1), kernel->context().boxSize(),
+                                                    kernel->context().periodicBoundaryConditions());
         auto p_12_nondirect = data.pos(1) - data.pos(0);
         EXPECT_EQ(p_12_nondirect, p_12);
         auto distance = std::sqrt(p_12 * p_12);

--- a/kernels/singlecpu/src/actions/SCPUEvaluateTopologyReactions.cpp
+++ b/kernels/singlecpu/src/actions/SCPUEvaluateTopologyReactions.cpp
@@ -32,6 +32,7 @@
 
 #include <readdy/kernel/singlecpu/actions/SCPUEvaluateTopologyReactions.h>
 #include <readdy/common/algorithm.h>
+#include <readdy/common/boundary_condition_operations.h>
 
 namespace readdy {
 namespace kernel {
@@ -165,7 +166,8 @@ SCPUEvaluateTopologyReactions::topology_reaction_events SCPUEvaluateTopologyReac
 
 
         if (!topology_registry.spatialReactionRegistry().empty()) {
-            const auto &d2 = context.distSquaredFun();
+            const auto &box = context.boxSize().data();
+            const auto &pbc = context.periodicBoundaryConditions().data();
             const auto &stateModel = kernel->getSCPUKernelStateModel();
             const auto &data = *stateModel.getParticleData();
             const auto &nl = *stateModel.getNeighborList();
@@ -193,7 +195,7 @@ SCPUEvaluateTopologyReactions::topology_reaction_events SCPUEvaluateTopologyReac
                             if(tt1 == -1 && tt2 == -1) return;
                             const auto &reactions = topology_registry.spatialReactionsByType(entry.type, tt1,
                                                                                              neighbor.type, tt2);
-                            const auto distSquared = d2(entry.pos, neighbor.pos);
+                            const auto distSquared = bcs::distSquared(entry.pos, neighbor.pos, box, pbc);
                             std::size_t reaction_index = 0;
                             for (const auto &reaction : reactions) {
                                 if (distSquared < reaction.radius() * reaction.radius()) {

--- a/kernels/singlecpu/src/observables/SCPUObservableFactory.cpp
+++ b/kernels/singlecpu/src/observables/SCPUObservableFactory.cpp
@@ -69,8 +69,8 @@ std::unique_ptr<readdy::model::observables::RadialDistribution>
 SCPUObservableFactory::radialDistribution(stride_type stride, std::vector<scalar> binBorders,
                                           std::vector<std::string> typeCountFrom, std::vector<std::string> typeCountTo,
                                           scalar particleDensity) const {
-    return {std::make_unique<SCPURadialDistribution<>>(kernel, stride, binBorders, typeCountFrom, typeCountTo,
-                                                     particleDensity)};
+    return {std::make_unique<readdy::model::observables::RadialDistribution>(kernel, stride, binBorders, typeCountFrom,
+                                                                             typeCountTo, particleDensity)};
 }
 
 std::unique_ptr<readdy::model::observables::Particles>

--- a/readdy/test/TestKernelContext.cpp
+++ b/readdy/test/TestKernelContext.cpp
@@ -38,6 +38,7 @@
 #include <readdy/testing/Utils.h>
 #include <readdy/testing/NOOPPotential.h>
 #include <readdy/model/potentials/PotentialsOrder1.h>
+#include <readdy/common/boundary_condition_operations.h>
 
 namespace m = readdy::model;
 
@@ -74,10 +75,9 @@ TEST_F(TestKernelContext, DistanceFunctions) {
     ctx.configure();
     ctx.boxSize() = {{4, 4, 4}};
     ctx.configure();
-    auto distSquared = ctx.distSquaredFun();
     readdy::Vec3 v1(-1.5, -1.5, 0.);
     readdy::Vec3 v2(+1.5, +1.5, 0.);
-    EXPECT_NEAR(distSquared(v1, v2), 2., 1e-9);
+    EXPECT_NEAR(readdy::bcs::distSquared(v1, v2, ctx.boxSize().data(), ctx.periodicBoundaryConditions().data()), 2., 1e-9);
 }
 
 TEST_F(TestKernelContext, BoxSize) {

--- a/readdy/test/TestMatrix33.cpp
+++ b/readdy/test/TestMatrix33.cpp
@@ -28,6 +28,7 @@
 
 #include "gtest/gtest.h"
 #include <readdy/common/numeric.h>
+#include <readdy/common/common.h>
 
 using mat = readdy::Matrix33;
 using vec = readdy::Vec3;
@@ -37,7 +38,7 @@ namespace {
 TEST(Matrix33, OuterProduct) {
     vec u(1, 2, 3);
     vec v(3, 2, 1);
-    auto outer = readdy::math::outerProduct(u, v);
+    auto outer = readdy::math::outerProduct<mat>(u, v);
     EXPECT_EQ(outer.at(0, 0), u[0] * v[0]);
     EXPECT_EQ(outer.at(0, 1), u[0] * v[1]);
     EXPECT_EQ(outer.at(0, 2), u[0] * v[2]);

--- a/readdy/test/TestTopologies.cpp
+++ b/readdy/test/TestTopologies.cpp
@@ -133,7 +133,7 @@ TEST_P(TestTopologies, AnglePotential) {
     topology_particle_t x_k{1, 1, 0, ctx.particle_types().idOf("Topology A")};
     auto top = kernel->stateModel().addTopology(0, {x_i, x_j, x_k});
     {
-        std::vector<angle_bond::angle> angles{{0, 1, 2, 1.0, readdy::util::numeric::pi()}};
+        std::vector<angle_bond::angle> angles{{0, 1, 2, 1.0, readdy::util::numeric::pi<readdy::scalar>()}};
         top->addAnglePotential<angle_bond>(std::move(angles));
     }
     auto fObs = kernel->observe().forces(1);
@@ -175,7 +175,7 @@ TEST_P(TestTopologies, MoreComplicatedAnglePotential) {
     topology_particle_t x_k{1.0, 0.5, -.3, ctx.particle_types().idOf("Topology A")};
     auto top = kernel->stateModel().addTopology(0, {x_i, x_j, x_k});
     {
-        std::vector<angle_bond::angle> angles{{0, 1, 2, 1.0, readdy::util::numeric::pi()}};
+        std::vector<angle_bond::angle> angles{{0, 1, 2, 1.0, readdy::util::numeric::pi<readdy::scalar>()}};
         top->addAnglePotential<angle_bond>(std::move(angles));
     }
     auto fObs = kernel->observe().forces(1);
@@ -235,7 +235,7 @@ TEST_P(TestTopologies, DihedralPotential) {
     topology_particle_t x_l{1, .1, 1, ctx.particle_types().idOf("Topology A")};
     auto top = kernel->stateModel().addTopology(0, {x_i, x_j, x_k, x_l});
     {
-        std::vector<dihedral_bond::dihedral_configuration> dihedrals{{0, 1, 2, 3, 1.0, 3, readdy::util::numeric::pi()}};
+        std::vector<dihedral_bond::dihedral_configuration> dihedrals{{0, 1, 2, 3, 1.0, 3, readdy::util::numeric::pi<readdy::scalar>()}};
         top->addTorsionPotential<dihedral_bond>(dihedrals);
     }
     auto fObs = kernel->observe().forces(1);
@@ -278,7 +278,7 @@ TEST_P(TestTopologies, DihedralPotentialSteeperAngle) {
     topology_particle_t x_l{1, 3, 1, ctx.particle_types().idOf("Topology A")};
     auto top = kernel->stateModel().addTopology(0, {x_i, x_j, x_k, x_l});
     {
-        std::vector<dihedral_bond::dihedral_configuration> dihedral{{0, 1, 2, 3, 1.0, 3, readdy::util::numeric::pi()}};
+        std::vector<dihedral_bond::dihedral_configuration> dihedral{{0, 1, 2, 3, 1.0, 3, readdy::util::numeric::pi<readdy::scalar>()}};
         top->addTorsionPotential(std::make_unique<dihedral_bond>(dihedral));
     }
     auto fObs = kernel->observe().forces(1);

--- a/readdy/test/TestTopologyGraphs.cpp
+++ b/readdy/test/TestTopologyGraphs.cpp
@@ -287,7 +287,7 @@ TEST_P(TestTopologyGraphs, MoreComplicatedAnglePotential) {
     ctx.boxSize() = {{10, 10, 10}};
     ctx.topology_registry().configureBondPotential("Topology A", "Topology A", {0., 1.});
     ctx.topology_registry().configureAnglePotential("Topology A", "Topology A", "Topology A",
-                                                    {1.0, readdy::util::numeric::pi()});
+                                                    {1.0, readdy::util::numeric::pi<readdy::scalar>()});
     topology_particle_t x_i{0.1, 0.1, 0.1, ctx.particle_types().idOf("Topology A")};
     topology_particle_t x_j{1.0, 0.0, 0.0, ctx.particle_types().idOf("Topology A")};
     topology_particle_t x_k{1.0, 0.5, -.3, ctx.particle_types().idOf("Topology A")};
@@ -348,7 +348,7 @@ TEST_P(TestTopologyGraphs, DihedralPotentialSteeperAngle) {
     ctx.topology_registry().configureBondPotential("Topology A", "Topology A", {0., 1.});
     kernel->context().topology_registry().configureTorsionPotential("Topology A", "Topology A", "Topology A",
                                                                     "Topology A",
-                                                                    {1.0, 3, readdy::util::numeric::pi()});
+                                                                    {1.0, 3, readdy::util::numeric::pi<readdy::scalar>()});
     top->configure();
     auto fObs = kernel->observe().forces(1);
     std::vector<readdy::Vec3> collectedForces;

--- a/tools/conda-recipe/build.sh
+++ b/tools/conda-recipe/build.sh
@@ -24,8 +24,8 @@ CMAKE_FLAGS+=" -DREADDY_INSTALL_UNIT_TEST_EXECUTABLE:BOOL=OFF"
 # hdf5 flags
 CMAKE_FLAGS+=" -DHDF5_INCLUDE_DIRS=${BUILD_PREFIX}/include"
 # version flags
-CMAKE_FLAGS+=" -DREADDY_VERSION=${PKG_BUILDNUM}"
-CMAKE_FLAGS+=" -DREADDY_BUILD_STRING=${PKG_HASH}"
+CMAKE_FLAGS+=" -DREADDY_VERSION=${PKG_VERSION}"
+CMAKE_FLAGS+=" -DREADDY_BUILD_STRING=${PKG_BUILDNUM}"
 
 #########################################################
 #                                                       #

--- a/wrappers/python/src/cxx/api/ExportKernelContext.cpp
+++ b/wrappers/python/src/cxx/api/ExportKernelContext.cpp
@@ -35,6 +35,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
 #include <readdy/model/Context.h>
+#include <readdy/common/boundary_condition_operations.h>
 
 namespace py = pybind11;
 
@@ -207,6 +208,21 @@ void exportKernelContext(py::module &module) {
             .def_property_readonly("reactions", [](KernelContext &self) -> ReactionRegistry& { return self.reactions(); }, rvp::reference_internal)
             .def_property_readonly("potentials", [](KernelContext &self) -> PotentialRegistry& { return self.potentials(); }, rvp::reference_internal)
             .def_property_readonly("topologies", [](KernelContext &self) -> TopologyRegistry& { return self.topology_registry(); }, rvp::reference_internal)
-            .def_property_readonly("compartments", [](KernelContext &self) -> CompartmentRegistry&  { return self.compartments(); }, rvp::reference_internal);
+            .def_property_readonly("compartments", [](KernelContext &self) -> CompartmentRegistry&  { return self.compartments(); }, rvp::reference_internal)
+            .def_property_readonly("shortest_difference_fun", [](const KernelContext &self) -> std::function<Vec3(const Vec3&, const Vec3 &)> {
+                return [&self](const Vec3 &v1, const Vec3 &v2) {
+                    return bcs::shortestDifference(v1, v2, self.boxSize(), self.periodicBoundaryConditions());
+                };
+            })
+            .def_property_readonly("fix_position_fun", [](const KernelContext &self) -> std::function<void(Vec3 &)> {
+                return [&self](Vec3 &position) {
+                    return bcs::fixPosition(position, self.boxSize(), self.periodicBoundaryConditions());
+                };
+            })
+            .def_property_readonly("dist_squared_fun", [](const KernelContext &self) -> std::function<scalar(const Vec3 &, const Vec3 &)> {
+                return [&self](const Vec3 &p1, const Vec3 &p2) {
+                    return bcs::distSquared(p1, p2, self.boxSize(), self.periodicBoundaryConditions());
+                };
+            });
 
 }

--- a/wrappers/python/src/cxx/api/ExportKernelContext.cpp
+++ b/wrappers/python/src/cxx/api/ExportKernelContext.cpp
@@ -192,9 +192,6 @@ void exportKernelContext(py::module &module) {
                           [](KernelContext &self, KernelContext::PeriodicBoundaryConditions pbc) {
                               self.periodicBoundaryConditions() = pbc;
                           })
-            .def_property_readonly("dist_squared_fun", &KernelContext::distSquaredFun)
-            .def_property_readonly("fix_position_fun", &KernelContext::fixPositionFun)
-            .def_property_readonly("shortest_difference_fun", &KernelContext::shortestDifferenceFun)
             .def("configure", &KernelContext::configure)
             .def("describe", &KernelContext::describe)
             .def("bounding_box_vertices", &KernelContext::getBoxBoundingVertices)


### PR DESCRIPTION
Periodic boundaries are now evaluated differently and the functions are called directly instead of through a `std::function` proxy.