### PR TITLE
[topology reactions / append particle] fix failed state

### DIFF
--- a/include/readdy/kernel/singlecpu/model/topologies/SCPUTopologyActions.h
+++ b/include/readdy/kernel/singlecpu/model/topologies/SCPUTopologyActions.h
@@ -205,7 +205,7 @@ public:
         auto entry = Entry(particle);
         insertIndex = data->addEntry(entry);
         auto firstNeighbor = neighbors[0];
-        topology->appendParticle(insertIndex, type, firstNeighbor->particleIndex, firstNeighbor->particleType());
+        topology->appendParticle(insertIndex, type, firstNeighbor, firstNeighbor->particleType());
         // new particles get appended to the end of the linked list
         newParticleIt = std::prev(topology->graph().vertices().end());
         for(auto it = neighbors.begin() + 1; it != neighbors.end(); ++it) {

--- a/include/readdy/model/topologies/GraphTopology.h
+++ b/include/readdy/model/topologies/GraphTopology.h
@@ -148,6 +148,9 @@ public:
     void appendParticle(particle_index newParticle, ParticleTypeId newParticleType,
                         particle_index counterPart, ParticleTypeId counterPartType);
 
+    void appendParticle(particle_index newParticle, ParticleTypeId newParticleType,
+            topology_graph::vertex_ref counterPart, ParticleTypeId counterPartType);
+
     void appendTopology(GraphTopology &other, particle_index otherParticle, ParticleTypeId otherNewParticleType,
                         particle_index thisParticle, ParticleTypeId thisNewParticleType, TopologyTypeId newType);
 

--- a/kernels/cpu/include/readdy/kernel/cpu/actions/topologies/CPUTopologyActions.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/topologies/CPUTopologyActions.h
@@ -133,7 +133,7 @@ public:
         insertIndex = data->addEntry(std::move(entry));
 
         auto firstNeighbor = neighbors[0];
-        topology->appendParticle(insertIndex, type, firstNeighbor->particleIndex, firstNeighbor->particleType());
+        topology->appendParticle(insertIndex, type, firstNeighbor, firstNeighbor->particleType());
         // new particles get appended to the end of the linked list
         newParticleIt = std::prev(topology->graph().vertices().end());
         for(auto it = neighbors.begin() + 1; it != neighbors.end(); ++it) {

--- a/readdy/main/model/topologies/GraphTopology.cpp
+++ b/readdy/main/model/topologies/GraphTopology.cpp
@@ -207,6 +207,26 @@ const bool GraphTopology::isNormalParticle(const Kernel &k) const {
 }
 
 void GraphTopology::appendParticle(particle_index newParticle, ParticleTypeId newParticleType,
+                                   topology_graph::vertex_ref counterPart, ParticleTypeId counterPartType) {
+
+    // this is costly so I am just assuming that the counter part iterator (vertex_ref) belongs to `this` topology...
+    //if(std::find(graph().vertices().begin(), graph().vertices().end(), *counterPart) == graph().vertices().end()) {
+    //    throw std::logic_error("Could not locate graph vertex iterator within vertices list.");
+    //}
+
+    particles.push_back(newParticle);
+    graph().addVertex(particles.size() - 1, newParticleType);
+
+    auto newParticleIt = std::prev(graph().vertices().end());
+    auto otherParticleIt = counterPart;
+    otherParticleIt->particleType() = counterPartType;
+
+    graph().addEdge(newParticleIt, otherParticleIt);
+
+    counterPart->particleType() = counterPartType;
+}
+
+void GraphTopology::appendParticle(particle_index newParticle, ParticleTypeId newParticleType,
                                    particle_index counterPart, ParticleTypeId counterPartType) {
     auto it = std::find(particles.begin(), particles.end(), counterPart);
     if(it != particles.end()) {


### PR DESCRIPTION
fix failed state where the particleIndex of the counter part in append particle could not be located inside the topology. Instead use iterator directly.