### PR TITLE
bugfix spatial topology reactions

### DIFF
--- a/kernels/cpu/src/actions/CPUEvaluateTopologyReactions.cpp
+++ b/kernels/cpu/src/actions/CPUEvaluateTopologyReactions.cpp
@@ -388,7 +388,7 @@ void CPUEvaluateTopologyReactions::handleTopologyTopologyReaction(CPUStateModel:
             // introduce edge if not already present
             auto v1 = t1->vertexForParticle(event.idx1);
             auto v2 = t1->vertexForParticle(event.idx2);
-            if(entry1Type == reaction.type1() && t1->type() == reaction.top_type1()) {
+            if(v1->particleType() == reaction.type1() && t1->type() == reaction.top_type1()) {
                 v1->particleType() = reaction.type_to1();
                 v2->particleType() = reaction.type_to2();
             } else {

--- a/kernels/singlecpu/src/actions/SCPUEvaluateTopologyReactions.cpp
+++ b/kernels/singlecpu/src/actions/SCPUEvaluateTopologyReactions.cpp
@@ -322,7 +322,8 @@ void SCPUEvaluateTopologyReactions::handleTopologyTopologyReaction(SCPUStateMode
             // introduce edge if not already present
             auto v1 = t1->vertexForParticle(event.idx1);
             auto v2 = t1->vertexForParticle(event.idx2);
-            if(entry1Type == reaction.type1() && t1->type() == reaction.top_type1()) {
+
+            if(v1->particleType() == reaction.type1() && t1->type() == reaction.top_type1()) {
                 v1->particleType() = reaction.type_to1();
                 v2->particleType() = reaction.type_to2();
             } else {

--- a/readdy/test/TestTopologyReactions.cpp
+++ b/readdy/test/TestTopologyReactions.cpp
@@ -475,23 +475,34 @@ TEMPLATE_TEST_CASE("Test topology reactions.", "[topologies]", SingleCPU, CPU) {
         SECTION("TTFusion") {
             Simulation sim (std::move(kernel));
 
-            sim.context().particleTypes().addTopologyType("X", 0);
+            sim.context().particleTypes().addTopologyType("X1", 0);
+            sim.context().particleTypes().addTopologyType("X2", 0);
             sim.context().particleTypes().addTopologyType("Y", 0);
             sim.context().particleTypes().addTopologyType("Z", 0);
             sim.context().topologyRegistry().addType("T");
             sim.context().topologyRegistry().addType("T2");
 
             sim.context().topologyRegistry().configureBondPotential("Y", "Z", {0., .1});
-            sim.context().topologyRegistry().addSpatialReaction("connect: T(X) + T(X) -> T2(Y--Z) [self=true]", 1e10, 1.);
+            sim.context().topologyRegistry().addSpatialReaction("connect: T(X1) + T(X2) -> T2(Y--Z)", 1e10, 1.);
+            
+            std::string x1type = "X1"; 
+            std::string x2type = "X2"; 
+            std::string ttype = "T";
+            REQUIRE(sim.context().topologyRegistry().spatialReactionsByType(x1type, ttype, x2type, ttype).size() == 1);
+            REQUIRE(sim.context().topologyRegistry().spatialReactionsByType(x2type, ttype, x1type, ttype).size() == 1);
 
-            auto p1 = sim.createTopologyParticle("X", {0, 0, 0});
-            auto p2 = sim.createTopologyParticle("X", {0, 0, 0});
+            auto p1 = sim.createTopologyParticle("X1", {0, 0, 0});
+            auto p2 = sim.createTopologyParticle("X2", {0, 0, 0});
             sim.addTopology("T", {p1});
             sim.addTopology("T", {p2});
 
+            auto topologies = sim.currentTopologies();
+
+            REQUIRE(topologies.size() == 2);
+
             sim.run(1, 1e-3);
 
-            auto topologies = sim.currentTopologies();
+            topologies = sim.currentTopologies();
 
             REQUIRE(topologies.size() == 1);
             auto top = topologies.at(0);


### PR DESCRIPTION
- fix bug where the type of a vertex was changed based on its entry, which has changed type already. Now instead uses the vertex itself.
- fix bug where no reaction of type `T1(X1)+T2(X2)-> something` would be performed because the hasher that resolves reactions for the tuple `(X1,T1,X2,T2)` was not permutation invariant with respect to swapping the particles in the case where `T1=T2`. Now `(X1,T1,X2,T2)` and `(X2,T2,X1,T1)` result in the same hash.