### PR TITLE
Context and simulation workflow also in c++ top level

### DIFF
--- a/include/readdy/api/Simulation.h
+++ b/include/readdy/api/Simulation.h
@@ -68,13 +68,16 @@ public:
     template<typename T>
     using observable_callback = typename std::function<void(typename T::result_type)>;
 
-    explicit Simulation(plugin::KernelProvider::kernel_ptr kernel) : _kernel(std::move(kernel)) {}
+    /** User provided context is copied, and no modifyable view on it is provided after construction of Simulation */
+    explicit Simulation(plugin::KernelProvider::kernel_ptr kernel, model::Context ctx) : _kernel(std::move(kernel)) {
+        _kernel->context() = std::move(ctx);
+    }
 
     /**
      * The default constructor.
      */
-    explicit Simulation(const std::string &kernel) : Simulation(
-            plugin::KernelProvider::getInstance().create(kernel)) {};
+    explicit Simulation(const std::string &kernel, model::Context ctx) : Simulation(
+            plugin::KernelProvider::getInstance().create(kernel), std::move(ctx)) {};
 
     /**
      * Creates a topology particle of a certain type at a position without adding it to the simulation box yet.
@@ -222,15 +225,6 @@ public:
      */
     const std::vector<Vec3> getAllParticlePositions() const {
         return _kernel->stateModel().getParticlePositions();
-    }
-
-    /**
-     * Yields a modifyable reference to the current context of this simulation. Can be used to set time-independent
-     * properties.
-     * @return the context
-     */
-    model::Context &context() {
-        return _kernel->context();
     }
 
     /**

--- a/kernels/cpu/src/nl/CellLinkedList.cpp
+++ b/kernels/cpu/src/nl/CellLinkedList.cpp
@@ -44,10 +44,7 @@
 #include <readdy/kernel/cpu/nl/CellLinkedList.h>
 #include <readdy/common/numeric.h>
 
-namespace readdy {
-namespace kernel {
-namespace cpu {
-namespace nl {
+namespace readdy::kernel::cpu::nl {
 
 CellLinkedList::CellLinkedList(data_type &data, const readdy::model::Context &context, thread_pool &pool)
         : _data(data), _context(context), _pool(pool) {}
@@ -250,7 +247,4 @@ void CompactCellLinkedList::setUpBins() {
     }
 }
 
-}
-}
-}
 }

--- a/readdy/test/TestSimulationLoop.cpp
+++ b/readdy/test/TestSimulationLoop.cpp
@@ -55,9 +55,9 @@ using namespace readdytesting::kernel;
 
 
 TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
-    readdy::Simulation simulation {create<TestType>()};
-
     SECTION("Correct number of timesteps") {
+        readdy::model::Context ctx;
+        readdy::Simulation simulation {create<TestType>(), ctx};
         unsigned int counter = 0;
         auto increment = [&counter](readdy::model::observables::NParticles::result_type result) {
             counter++;
@@ -67,6 +67,8 @@ TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
         REQUIRE(counter == 4);
     }
     SECTION("Simple stopping criterion") {
+        readdy::model::Context ctx;
+        readdy::Simulation simulation {create<TestType>(), ctx};
         unsigned int counter = 0;
         auto increment = [&counter](readdy::model::observables::NParticles::result_type result) {
             counter++;
@@ -80,10 +82,12 @@ TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
         REQUIRE(counter == 6);
     }
     SECTION("Complex stopping criterion") {
-        simulation.context().particleTypes().add("A", 0.);
+        readdy::model::Context ctx;
+        ctx.particleTypes().add("A", 0.);
         // A -> A + A, with probability = 1 each timestep. After 3 timesteps there will be 8 particles.
         // The counter will be 4 by then.
-        simulation.context().reactions().addFission("bla", "A", "A", "A", 1e8, 0.);
+        ctx.reactions().addFission("bla", "A", "A", "A", 1e8, 0.);
+        readdy::Simulation simulation {create<TestType>(), ctx};
         simulation.addParticle("A", 0, 0, 0);
         unsigned int counter = 0;
         bool doStop = false;
@@ -101,10 +105,12 @@ TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
         REQUIRE(counter == 4);
     }
     SECTION("Skin size sanity check") {
-        simulation.context().particleTypes().add("A", 1.);
-        simulation.context().boxSize() = {{10., 10., 10.}};
-        simulation.context().periodicBoundaryConditions() = {{true, true, true}};
-        simulation.context().potentials().addHarmonicRepulsion("A", "A", 1., 2.);
+        readdy::model::Context ctx;
+        ctx.particleTypes().add("A", 1.);
+        ctx.boxSize() = {{10., 10., 10.}};
+        ctx.periodicBoundaryConditions() = {{true, true, true}};
+        ctx.potentials().addHarmonicRepulsion("A", "A", 1., 2.);
+        readdy::Simulation simulation {create<TestType>(), ctx};
         simulation.addParticle("A", 0., 0., 0.);
         simulation.addParticle("A", 1.5, 0., 0.);
         auto loop = simulation.createLoop(.001);

--- a/readdy/test/TestTopologyReactions.cpp
+++ b/readdy/test/TestTopologyReactions.cpp
@@ -473,18 +473,20 @@ TEMPLATE_TEST_CASE("Test topology reactions.", "[topologies]", SingleCPU, CPU) {
 
     SECTION("Reaction types") {
         SECTION("TTFusion") {
-            Simulation sim (std::move(kernel));
+            model::Context ctx;
 
-            sim.context().particleTypes().addTopologyType("X1", 0);
-            sim.context().particleTypes().addTopologyType("X2", 0);
-            sim.context().particleTypes().addTopologyType("Y", 0);
-            sim.context().particleTypes().addTopologyType("Z", 0);
-            sim.context().topologyRegistry().addType("T");
-            sim.context().topologyRegistry().addType("T2");
+            ctx.particleTypes().addTopologyType("X1", 0);
+            ctx.particleTypes().addTopologyType("X2", 0);
+            ctx.particleTypes().addTopologyType("Y", 0);
+            ctx.particleTypes().addTopologyType("Z", 0);
+            ctx.topologyRegistry().addType("T");
+            ctx.topologyRegistry().addType("T2");
 
-            sim.context().topologyRegistry().configureBondPotential("Y", "Z", {0., .1});
-            sim.context().topologyRegistry().addSpatialReaction("connect: T(X1) + T(X2) -> T2(Y--Z)", 1e10, 1.);
-            
+            ctx.topologyRegistry().configureBondPotential("Y", "Z", {0., .1});
+            ctx.topologyRegistry().addSpatialReaction("connect: T(X1) + T(X2) -> T2(Y--Z)", 1e10, 1.);
+
+            Simulation sim (std::move(kernel), ctx);
+
             std::string x1type = "X1"; 
             std::string x2type = "X2"; 
             std::string ttype = "T";
@@ -519,19 +521,21 @@ TEMPLATE_TEST_CASE("Test topology reactions.", "[topologies]", SingleCPU, CPU) {
         }
 
         SECTION("TTSelfFusion") {
-            Simulation sim (kernel->name());
+            model::Context ctx;
 
-            sim.context().particleTypes().addTopologyType("X", 0);
-            sim.context().particleTypes().addTopologyType("Y", 0);
-            sim.context().particleTypes().addTopologyType("Z", 0);
-            sim.context().topologyRegistry().addType("T");
-            sim.context().topologyRegistry().addType("T2");
+            ctx.particleTypes().addTopologyType("X", 0);
+            ctx.particleTypes().addTopologyType("Y", 0);
+            ctx.particleTypes().addTopologyType("Z", 0);
+            ctx.topologyRegistry().addType("T");
+            ctx.topologyRegistry().addType("T2");
 
-            sim.context().topologyRegistry().configureBondPotential("Y", "Z", {.0, .01});
-            sim.context().topologyRegistry().configureBondPotential("X", "X", {.0, .01});
-            sim.context().topologyRegistry().configureBondPotential("X", "Y", {.0, .01});
-            sim.context().topologyRegistry().configureBondPotential("X", "Z", {.0, .01});
-            sim.context().topologyRegistry().addSpatialReaction("connect: T(X) + T(X) -> T2(Y--Z) [self=true]", 1e10, 1.);
+            ctx.topologyRegistry().configureBondPotential("Y", "Z", {.0, .01});
+            ctx.topologyRegistry().configureBondPotential("X", "X", {.0, .01});
+            ctx.topologyRegistry().configureBondPotential("X", "Y", {.0, .01});
+            ctx.topologyRegistry().configureBondPotential("X", "Z", {.0, .01});
+            ctx.topologyRegistry().addSpatialReaction("connect: T(X) + T(X) -> T2(Y--Z) [self=true]", 1e10, 1.);
+
+            Simulation sim (kernel->name(), ctx);
 
             auto p1 = sim.createTopologyParticle("X", {0, 0, -.01});
             auto p2 = sim.createTopologyParticle("X", {0, 0, 0});

--- a/readdy/test/TestTopologyReactionsExternal.cpp
+++ b/readdy/test/TestTopologyReactionsExternal.cpp
@@ -52,9 +52,7 @@ using namespace readdy;
 using namespace readdytesting::kernel;
 
 TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU, CPU) {
-    Simulation simulation {create<TestType>()};
-
-    auto &ctx = simulation.context();
+    readdy::model::Context ctx;
 
     ctx.topologyRegistry().addType("T");
     ctx.particleTypes().add("Topology A", 1.0, readdy::model::particleflavor::TOPOLOGY);
@@ -70,6 +68,7 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
     ctx.boxSize() = {{10, 10, 10}};
 
     SECTION("Enzymatic reaction") {
+        Simulation simulation {create<TestType>(), ctx};
         model::TopologyParticle x_0{0., 0., 0., ctx.particleTypes().idOf("Topology A")};
         {
             auto tid = ctx.topologyRegistry().addType("MyType");

--- a/readdy/test/TestTopologyReactionsExternal.cpp
+++ b/readdy/test/TestTopologyReactionsExternal.cpp
@@ -68,17 +68,19 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
     ctx.boxSize() = {{10, 10, 10}};
 
     SECTION("Enzymatic reaction") {
+        ctx.reactions().addEnzymatic("TopologyEnzymatic", "Topology A", "A", "B", 1e16, 1.0);
+
         Simulation simulation {create<TestType>(), ctx};
-        model::TopologyParticle x_0{0., 0., 0., ctx.particleTypes().idOf("Topology A")};
+
+        model::TopologyParticle x_0{0., 0., 0., simulation.context().particleTypes().idOf("Topology A")};
         {
             auto tid = ctx.topologyRegistry().addType("MyType");
             simulation.stateModel().addTopology(tid, {x_0});
         }
+
         simulation.stateModel().addParticle(
                 model::Particle(0., 0., 0., ctx.particleTypes().idOf("A"))
         );
-        ctx.reactions().addEnzymatic("TopologyEnzymatic", "Topology A", "A", "B", 1e16, 1.0);
-
         auto particles_beforehand = simulation.stateModel().getParticles();
 
         {
@@ -114,6 +116,7 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
     }
 
     SECTION("Get topology for particle") {
+        Simulation simulation {create<TestType>(), ctx};
         model::TopologyParticle x_0{0., 0., 0., ctx.particleTypes().idOf("Topology A")};
         auto toplogy = simulation.addTopology("T", {x_0});
         simulation.addParticle("A", 0, 0, 0);
@@ -128,15 +131,36 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
         // check that the particles that are contained in (active) topologies point to their respective topologies, also
         // and especially after topology split reactions
         using namespace readdy;
-        simulation.context().periodicBoundaryConditions() = {{true, true, true}};
-        simulation.context().boxSize() = {{100, 100, 100}};
-        simulation.context().topologyRegistry().addType("TA");
+        
+        ctx.periodicBoundaryConditions() = {{true, true, true}};
+        ctx.boxSize() = {{100, 100, 100}};
+        ctx.topologyRegistry().addType("TA");
         //auto topAId = sim.registerParticleType("Topology A", 10., model::particleflavor::TOPOLOGY);
         //auto aId = sim.registerParticleType("A", 10.);
-        auto topAId = simulation.context().particleTypes().idOf("Topology A");
-        auto aId = simulation.context().particleTypes().idOf("A");
-        simulation.context().topologyRegistry().configureBondPotential("Topology A", "Topology A", {10, 1});
+        auto topAId = ctx.particleTypes().idOf("Topology A");
+        auto aId = ctx.particleTypes().idOf("A");
+        ctx.topologyRegistry().configureBondPotential("Topology A", "Topology A", {10, 1});
 
+        model::top::reactions::StructuralTopologyReaction r {"r", [aId](model::top::GraphTopology& top) {
+            model::top::reactions::Recipe recipe (top);
+            if(top.getNParticles() > 1) {
+                auto rnd = model::rnd::uniform_int(0, static_cast<const int>(top.getNParticles() - 2));
+                auto it1 = top.graph().vertices().begin();
+                auto it2 = std::next(it1, 1);
+                if(rnd > 0) {
+                    std::advance(it1, rnd);
+                    std::advance(it2, rnd);
+                }
+                recipe.removeEdge(it1, it2);
+            } else {
+                recipe.changeParticleType(top.graph().vertices().begin(), aId);
+            }
+            return recipe;
+        }, .7};
+        ctx.topologyRegistry().addStructuralReaction("TA", r);
+
+        Simulation simulation {create<TestType>(), ctx};
+        
         std::vector<model::TopologyParticle> topologyParticles;
         {
             topologyParticles.reserve(90);
@@ -156,25 +180,6 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
             }
         }
 
-        model::top::reactions::StructuralTopologyReaction r {"r", [aId](model::top::GraphTopology& top) {
-            model::top::reactions::Recipe recipe (top);
-            if(top.getNParticles() > 1) {
-                auto rnd = model::rnd::uniform_int(0, static_cast<const int>(top.getNParticles() - 2));
-                auto it1 = top.graph().vertices().begin();
-                auto it2 = std::next(it1, 1);
-                if(rnd > 0) {
-                    std::advance(it1, rnd);
-                    std::advance(it2, rnd);
-                }
-                recipe.removeEdge(it1, it2);
-            } else {
-                recipe.changeParticleType(top.graph().vertices().begin(), aId);
-            }
-            return recipe;
-        }, .7};
-
-        simulation.context().topologyRegistry().addStructuralReaction("TA", r);
-
         simulation.run(35, 1.);
 
         log::trace("got n topologies: {}", simulation.currentTopologies().size());
@@ -186,35 +191,35 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
     }
 
     SECTION("The parser") {
-        auto &context = simulation.context();
-        context.topologyRegistry().addType("1");
-        context.topologyRegistry().addType("2");
-        context.topologyRegistry().addType("3");
-        context.topologyRegistry().addType("4");
-        context.topologyRegistry().addType("5");
-        context.topologyRegistry().addType("6");
-        context.topologyRegistry().addType("T1");
-        context.topologyRegistry().addType("T2");
-        context.topologyRegistry().addType("T3");
-        context.topologyRegistry().addType("T4");
-        context.particleTypes().add("p1", 1.);
-        context.particleTypes().add("p2", 1.);
-        context.particleTypes().add("p3", 1.);
-        context.particleTypes().add("p4", 1.);
+        
+        ctx.topologyRegistry().addType("1");
+        ctx.topologyRegistry().addType("2");
+        ctx.topologyRegistry().addType("3");
+        ctx.topologyRegistry().addType("4");
+        ctx.topologyRegistry().addType("5");
+        ctx.topologyRegistry().addType("6");
+        ctx.topologyRegistry().addType("T1");
+        ctx.topologyRegistry().addType("T2");
+        ctx.topologyRegistry().addType("T3");
+        ctx.topologyRegistry().addType("T4");
+        ctx.particleTypes().add("p1", 1.);
+        ctx.particleTypes().add("p2", 1.);
+        ctx.particleTypes().add("p3", 1.);
+        ctx.particleTypes().add("p4", 1.);
 
-        readdy::model::top::reactions::STRParser parser (context.topologyRegistry());
+        readdy::model::top::reactions::STRParser parser (ctx.topologyRegistry());
 
         {
             auto r = parser.parse("topology-topology fusion type1: T1 (p1) + T2 (p2) -> T3 (p3--p4) [self=true]", 10., 11.);
             REQUIRE(r.mode() == readdy::model::top::reactions::STRMode::TT_FUSION_ALLOW_SELF);
-            REQUIRE(r.top_type1() == context.topologyRegistry().idOf("T1"));
-            REQUIRE(r.top_type2() == context.topologyRegistry().idOf("T2"));
-            REQUIRE(r.type1() == context.particleTypes().idOf("p1"));
-            REQUIRE(r.type2() == context.particleTypes().idOf("p2"));
-            REQUIRE(r.top_type_to1() == context.topologyRegistry().idOf("T3"));
+            REQUIRE(r.top_type1() == ctx.topologyRegistry().idOf("T1"));
+            REQUIRE(r.top_type2() == ctx.topologyRegistry().idOf("T2"));
+            REQUIRE(r.type1() == ctx.particleTypes().idOf("p1"));
+            REQUIRE(r.type2() == ctx.particleTypes().idOf("p2"));
+            REQUIRE(r.top_type_to1() == ctx.topologyRegistry().idOf("T3"));
             REQUIRE(r.top_type_to2() == readdy::EmptyTopologyId);
-            REQUIRE(r.type_to1() == context.particleTypes().idOf("p3"));
-            REQUIRE(r.type_to2() == context.particleTypes().idOf("p4"));
+            REQUIRE(r.type_to1() == ctx.particleTypes().idOf("p3"));
+            REQUIRE(r.type_to2() == ctx.particleTypes().idOf("p4"));
             REQUIRE(r.name() == "topology-topology fusion type1");
             REQUIRE(r.rate() == 10.);
             REQUIRE(r.radius() == 11.);
@@ -222,14 +227,14 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
         {
             auto r = parser.parse("topology-topology fusion type2: T1 (p1) + T2 (p2) -> T3 (p3--p4)", 10., 11.);
             REQUIRE(r.mode() == readdy::model::top::reactions::STRMode::TT_FUSION);
-            REQUIRE(r.top_type1() == context.topologyRegistry().idOf("T1"));
-            REQUIRE(r.top_type2() == context.topologyRegistry().idOf("T2"));
-            REQUIRE(r.type1() == context.particleTypes().idOf("p1"));
-            REQUIRE(r.type2() == context.particleTypes().idOf("p2"));
-            REQUIRE(r.top_type_to1() == context.topologyRegistry().idOf("T3"));
+            REQUIRE(r.top_type1() == ctx.topologyRegistry().idOf("T1"));
+            REQUIRE(r.top_type2() == ctx.topologyRegistry().idOf("T2"));
+            REQUIRE(r.type1() == ctx.particleTypes().idOf("p1"));
+            REQUIRE(r.type2() == ctx.particleTypes().idOf("p2"));
+            REQUIRE(r.top_type_to1() == ctx.topologyRegistry().idOf("T3"));
             REQUIRE(r.top_type_to2() == readdy::EmptyTopologyId);
-            REQUIRE(r.type_to1() == context.particleTypes().idOf("p3"));
-            REQUIRE(r.type_to2() == context.particleTypes().idOf("p4"));
+            REQUIRE(r.type_to1() == ctx.particleTypes().idOf("p3"));
+            REQUIRE(r.type_to2() == ctx.particleTypes().idOf("p4"));
             REQUIRE(r.name() == "topology-topology fusion type2");
             REQUIRE(r.rate() == 10.);
             REQUIRE(r.radius() == 11.);
@@ -237,14 +242,14 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
         {
             auto r = parser.parse("topology-topology enzymatic type: T1 (p1) + T2 (p2) -> T3 (p3) + T4 (p4)", 10., 11.);
             REQUIRE(r.mode() == readdy::model::top::reactions::STRMode::TT_ENZYMATIC);
-            REQUIRE(r.top_type1() == context.topologyRegistry().idOf("T1"));
-            REQUIRE(r.top_type2() == context.topologyRegistry().idOf("T2"));
-            REQUIRE(r.type1() == context.particleTypes().idOf("p1"));
-            REQUIRE(r.type2() == context.particleTypes().idOf("p2"));
-            REQUIRE(r.top_type_to1() == context.topologyRegistry().idOf("T3"));
-            REQUIRE(r.top_type_to2() == context.topologyRegistry().idOf("T4"));
-            REQUIRE(r.type_to1() == context.particleTypes().idOf("p3"));
-            REQUIRE(r.type_to2() == context.particleTypes().idOf("p4"));
+            REQUIRE(r.top_type1() == ctx.topologyRegistry().idOf("T1"));
+            REQUIRE(r.top_type2() == ctx.topologyRegistry().idOf("T2"));
+            REQUIRE(r.type1() == ctx.particleTypes().idOf("p1"));
+            REQUIRE(r.type2() == ctx.particleTypes().idOf("p2"));
+            REQUIRE(r.top_type_to1() == ctx.topologyRegistry().idOf("T3"));
+            REQUIRE(r.top_type_to2() == ctx.topologyRegistry().idOf("T4"));
+            REQUIRE(r.type_to1() == ctx.particleTypes().idOf("p3"));
+            REQUIRE(r.type_to2() == ctx.particleTypes().idOf("p4"));
             REQUIRE(r.name() == "topology-topology enzymatic type");
             REQUIRE(r.rate() == 10.);
             REQUIRE(r.radius() == 11.);
@@ -252,14 +257,14 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
         {
             auto r = parser.parse("topology-particle fusion type: T1 (p1) + (p2) -> T2 (p3--p4)", 10., 11.);
             REQUIRE(r.mode() == readdy::model::top::reactions::STRMode::TP_FUSION);
-            REQUIRE(r.top_type1() == context.topologyRegistry().idOf("T1"));
+            REQUIRE(r.top_type1() == ctx.topologyRegistry().idOf("T1"));
             REQUIRE(r.top_type2() == readdy::EmptyTopologyId);
-            REQUIRE(r.type1() == context.particleTypes().idOf("p1"));
-            REQUIRE(r.type2() == context.particleTypes().idOf("p2"));
-            REQUIRE(r.top_type_to1() == context.topologyRegistry().idOf("T2"));
+            REQUIRE(r.type1() == ctx.particleTypes().idOf("p1"));
+            REQUIRE(r.type2() == ctx.particleTypes().idOf("p2"));
+            REQUIRE(r.top_type_to1() == ctx.topologyRegistry().idOf("T2"));
             REQUIRE(r.top_type_to2() == readdy::EmptyTopologyId);
-            REQUIRE(r.type_to1() == context.particleTypes().idOf("p3"));
-            REQUIRE(r.type_to2() == context.particleTypes().idOf("p4"));
+            REQUIRE(r.type_to1() == ctx.particleTypes().idOf("p3"));
+            REQUIRE(r.type_to2() == ctx.particleTypes().idOf("p4"));
             REQUIRE(r.name() == "topology-particle fusion type");
             REQUIRE(r.rate() == 10.);
             REQUIRE(r.radius() == 11.);
@@ -267,14 +272,14 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
         {
             auto r = parser.parse("topology-particle enzymatic type: T1 (p1) + (p2) -> T2 (p3) + (p4)", 10., 11.);
             REQUIRE(r.mode() == readdy::model::top::reactions::STRMode::TP_ENZYMATIC);
-            REQUIRE(r.top_type1() == context.topologyRegistry().idOf("T1"));
+            REQUIRE(r.top_type1() == ctx.topologyRegistry().idOf("T1"));
             REQUIRE(r.top_type2() == readdy::EmptyTopologyId);
-            REQUIRE(r.type1() == context.particleTypes().idOf("p1"));
-            REQUIRE(r.type2() == context.particleTypes().idOf("p2"));
-            REQUIRE(r.top_type_to1() == context.topologyRegistry().idOf("T2"));
+            REQUIRE(r.type1() == ctx.particleTypes().idOf("p1"));
+            REQUIRE(r.type2() == ctx.particleTypes().idOf("p2"));
+            REQUIRE(r.top_type_to1() == ctx.topologyRegistry().idOf("T2"));
             REQUIRE(r.top_type_to2() == readdy::EmptyTopologyId);
-            REQUIRE(r.type_to1() == context.particleTypes().idOf("p3"));
-            REQUIRE(r.type_to2() == context.particleTypes().idOf("p4"));
+            REQUIRE(r.type_to1() == ctx.particleTypes().idOf("p3"));
+            REQUIRE(r.type_to2() == ctx.particleTypes().idOf("p4"));
             REQUIRE(r.name() == "topology-particle enzymatic type");
             REQUIRE(r.rate() == 10.);
             REQUIRE(r.radius() == 11.);
@@ -282,14 +287,18 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
     }
 
     SECTION("Attach topologies") {
-        simulation.context().periodicBoundaryConditions() = {{true, true, true}};
-        simulation.context().topologyRegistry().addType("TA");
-        simulation.context().boxSize() = {{15, 15, 15}};
-        simulation.context().particleTypes().add("middle", 0., model::particleflavor::TOPOLOGY);
-        simulation.context().particleTypes().add("end", 0., model::particleflavor::TOPOLOGY);
-        simulation.context().topologyRegistry().configureBondPotential("middle", "middle", {.00000001, 1});
-        simulation.context().topologyRegistry().configureBondPotential("middle", "end", {.00000001, 1});
-        simulation.context().topologyRegistry().configureBondPotential("end", "end", {.00000001, 1});
+        ctx.periodicBoundaryConditions() = {{true, true, true}};
+        ctx.topologyRegistry().addType("TA");
+        ctx.boxSize() = {{15, 15, 15}};
+        ctx.particleTypes().add("middle", 0., model::particleflavor::TOPOLOGY);
+        ctx.particleTypes().add("end", 0., model::particleflavor::TOPOLOGY);
+        ctx.topologyRegistry().configureBondPotential("middle", "middle", {.00000001, 1});
+        ctx.topologyRegistry().configureBondPotential("middle", "end", {.00000001, 1});
+        ctx.topologyRegistry().configureBondPotential("end", "end", {.00000001, 1});
+        // register attach reaction that transforms (end, A) -> (middle, end)
+        ctx.topologyRegistry().addSpatialReaction("merge: TA (end) + TA (end) -> TA (middle--middle)", 1e3, 1.5);
+
+        Simulation simulation {create<TestType>(), ctx};
 
         for(int i = 0; i < 3; ++i) {
             auto top = simulation.addTopology("TA", {simulation.createTopologyParticle("end", {0. - 4. + 3*i, 0., 0.}),
@@ -305,8 +314,7 @@ TEMPLATE_TEST_CASE("Test topology reactions external", "[topologies]", SingleCPU
             }
         }
 
-        // register attach reaction that transforms (end, A) -> (middle, end)
-        simulation.context().topologyRegistry().addSpatialReaction("merge: TA (end) + TA (end) -> TA (middle--middle)", 1e3, 1.5);
+        
 
         REQUIRE(simulation.currentTopologies().size() == 3);
         simulation.run(6, 1.);

--- a/wrappers/python/src/cxx/api/ApiModule.cpp
+++ b/wrappers/python/src/cxx/api/ApiModule.cpp
@@ -84,7 +84,7 @@ void exportApi(py::module &api) {
     py::enum_<readdy::api::TorsionType>(api, "TorsionType").value("COS_DIHEDRAL", readdy::api::TorsionType::COS_DIHEDRAL);
 
     py::class_<sim> simulation(api, "Simulation");
-    simulation.def(py::init<std::string>())
+    simulation.def(py::init<std::string, ctx>())
             .def_property_readonly("single_precision", &sim::singlePrecision)
             .def_property_readonly("double_precision", &sim::doublePrecision)
             .def("add_particle", [](sim &self, const std::string &type, const vec &pos) {

--- a/wrappers/python/src/cxx/api/ApiModule.cpp
+++ b/wrappers/python/src/cxx/api/ApiModule.cpp
@@ -133,10 +133,8 @@ void exportApi(py::module &api) {
                 }
                 return particles;
             })
-            .def_property("context", [](sim &self) -> readdy::model::Context & {
+            .def_property_readonly("context", [](sim &self) -> const readdy::model::Context& {
                 return self.context();
-            }, [](sim &self, const readdy::model::Context &context) {
-                self.context() = context;
             })
             .def("create_loop", &sim::createLoop, py::keep_alive<0, 1>(), py::return_value_policy::reference_internal)
             .def("run", [](sim &self, const readdy::TimeStep steps, const readdy::scalar timeStep) {

--- a/wrappers/python/src/python/readdy/api/simulation.py
+++ b/wrappers/python/src/python/readdy/api/simulation.py
@@ -35,7 +35,7 @@
 """
 Created on 08.09.17
 
-@author: clonker
+@author: clonker, chrisfroe
 """
 from readdy.api.conf.KernelConfiguration import CPUKernelConfiguration as _CPUKernelConfiguration
 from readdy.api.conf.KernelConfiguration import NOOPKernelConfiguration as _NOOPKernelConfiguration
@@ -72,8 +72,7 @@ class Simulation(object):
                              "are available.".format(kernel, ", ".join(['"{}"'.format(x) for x in available_kernels])))
         self._unit_conf = unit_config
         self._kernel = kernel
-        self._simulation = _Simulation(kernel)
-        self._simulation.context = context
+        self._simulation = _Simulation(kernel, context)
 
         self._evaluate_topology_reactions = True
         self._evaluate_forces = True

--- a/wrappers/python/src/python/readdy/tests/test_io.py
+++ b/wrappers/python/src/python/readdy/tests/test_io.py
@@ -45,6 +45,7 @@ import numpy as np
 import readdy._internal.readdybinding.common as common
 import readdy._internal.readdybinding.common.io as io
 from readdy._internal.readdybinding.api import Simulation
+from readdy._internal.readdybinding.api import Context
 
 from readdy.util.testing_utils import ReaDDyTestCase
 from readdy.util.trajectory_utils import TrajectoryReader
@@ -62,10 +63,11 @@ class TestSchemeApi(ReaDDyTestCase):
 
     def test_write_trajectory(self):
         traj_fname = os.path.join(self.dir, "traj.h5")
-        simulation = Simulation("SingleCPU")
-        simulation.context.box_size = [5., 5., 5.]
-        simulation.context.particle_types.add("A", 0.0)
-        simulation.context.reactions.add_conversion("A->A", "A", "A", 1.)
+        context = Context()
+        context.box_size = [5., 5., 5.]
+        context.particle_types.add("A", 0.0)
+        context.reactions.add_conversion("A->A", "A", "A", 1.)
+        simulation = Simulation("SingleCPU", context)
 
         def callback(_):
             simulation.add_particle("A", common.Vec(0, 0, 0))
@@ -112,9 +114,10 @@ class TestSchemeApi(ReaDDyTestCase):
 
     def test_write_trajectory_as_observable(self):
         traj_fname = os.path.join(self.dir, "traj_as_obs.h5")
-        simulation = Simulation("SingleCPU")
-        simulation.context.box_size = [5., 5., 5.]
-        simulation.context.particle_types.add("A", 0.0)
+        context = Context()
+        context.box_size = [5., 5., 5.]
+        context.particle_types.add("A", 0.0)
+        simulation = Simulation("SingleCPU", context)
 
         def callback(_):
             simulation.add_particle("A", common.Vec(0, 0, 0))

--- a/wrappers/python/src/python/readdy/tests/test_io_utils.py
+++ b/wrappers/python/src/python/readdy/tests/test_io_utils.py
@@ -62,15 +62,16 @@ class TestIOUtils(ReaDDyTestCase):
         cls.dir = tempfile.mkdtemp("test-config-io")
         cls.fname = os.path.join(cls.dir, "test_io_utils.h5")
 
-        sim = api.Simulation("CPU")
-        sim.context.particle_types.add("A", 1.)
-        sim.context.particle_types.add("B", 2.)
-        sim.context.particle_types.add("C", 3.)
-        sim.context.reactions.add_conversion("mylabel", "A", "B", .00001)
-        sim.context.reactions.add_conversion("A->B", "A", "B", 1.)
+        context = api.Context()
+        context.particle_types.add("A", 1.)
+        context.particle_types.add("B", 2.)
+        context.particle_types.add("C", 3.)
+        context.reactions.add_conversion("mylabel", "A", "B", .00001)
+        context.reactions.add_conversion("A->B", "A", "B", 1.)
         fusion_rate = 0.4
         educt_distance = 0.2
-        sim.context.reactions.add_fusion("B+C->A", "B", "C", "A", fusion_rate, educt_distance, .5, .5)
+        context.reactions.add_fusion("B+C->A", "B", "C", "A", fusion_rate, educt_distance, .5, .5)
+        sim = api.Simulation("CPU", context)
         with contextlib.closing(io.File.create(cls.fname)) as f:
             loop = sim.create_loop(.1)
             loop.write_config_to_file(f)

--- a/wrappers/python/src/python/readdy/tests/test_scheme_api.py
+++ b/wrappers/python/src/python/readdy/tests/test_scheme_api.py
@@ -37,6 +37,7 @@ import unittest
 import numpy as np
 
 from readdy._internal.readdybinding.api import Simulation
+from readdy._internal.readdybinding.api import Context
 from readdy._internal.readdybinding.common import Vec
 
 from readdy.util.testing_utils import ReaDDyTestCase
@@ -44,7 +45,7 @@ from readdy.util.testing_utils import ReaDDyTestCase
 
 class TestSchemeApi(ReaDDyTestCase):
     def test_sanity(self):
-        simulation = Simulation("SingleCPU")
+        simulation = Simulation("SingleCPU", Context())
         loop = simulation.create_loop(1.)
         loop.use_integrator("EulerBDIntegrator")
         loop.evaluate_forces(False)
@@ -53,8 +54,9 @@ class TestSchemeApi(ReaDDyTestCase):
         loop.run(10)
 
     def test_interrupt_simple(self):
-        sim = Simulation("SingleCPU")
-        sim.context.particle_types.add("A", 0.1)
+        context = Context()
+        context.particle_types.add("A", 0.1)
+        sim = Simulation("SingleCPU", context)
         # Define counter as list. This is a workaround because nosetest will complain otherwise.
         counter = [0]
 
@@ -67,10 +69,11 @@ class TestSchemeApi(ReaDDyTestCase):
         np.testing.assert_equal(counter[0], 6)
 
     def test_interrupt_maxparticles(self):
-        sim = Simulation("SingleCPU")
-        sim.context.particle_types.add("A", 0.1)
+        context = Context()
+        context.particle_types.add("A", 0.1)
+        context.reactions.add_fission("bla", "A", "A", "A", 1000., 0., 0.5, 0.5)
+        sim = Simulation("SingleCPU", context)
         sim.add_particle("A", Vec(0, 0, 0))
-        sim.context.reactions.add_fission("bla", "A", "A", "A", 1000., 0., 0.5, 0.5)
         counter = [0]
         shall_stop = [False]
 


### PR DESCRIPTION
In python we have the workflow
```python
system = readdy.ReactionDiffusionSystem(...)
# configure
...
simulation = system.simulation()
# simulate
```

This PR suggests the same for the c++ top level api, i.e.
```cpp
readdy::model::Context ctx;
// configure
...
// context is currently copied here, further changes to `ctx` are 
// not propagated after creation of simulation
readdy::Simulation simulation("CPU", ctx); 
// the context of simulation is now read-only
const auto bs1 = simulation.context().boxSize(); // this works
auto bs2 = simulation.context().boxSize(); // this doesn't
```
Why is this good? E.g. for the MPI Kernel, one needs to know the maximum cutoff for domain construction. To do this in a clean way means to construct domains when the kernel is constructed. In the above workflow the kernel is constructed, when the simulation is constructed. Hence, the context must be finalized when creating the simulation object.

All of the tests are semantically the same as before. Only one sanity test was adding reactions in an observable callback. Such a thing can still be done if necessary with low-level simulation, i.e. dealing with the kernel directly.