### PR TITLE
Github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: readdy_ci
+
+on: [push, pull_request]
+
+jobs:
+  readdy_ci:
+    name: readdy_ci (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest']#, 'windows-latest']
+        python-version: ['3.6', '3.7']#, '3.8']
+    steps:
+      - uses: actions/checkout@v2
+      - run: echo ${{github.ref}}
+      - uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+      - name: prepare conda
+        shell: bash -l {0}
+        run: |
+          conda config --set always_yes true
+          conda update --all
+          conda install -q conda-build=3.16.2
+          conda clean --all -y
+          conda install conda-verify
+      - name: build readdy conda package
+        shell: bash -l {0}
+        run: conda build -c defaults -c conda-forge tools/conda-recipe
+      - name: upload conda package
+        shell: bash -l {0}
+        # only upload conda package when origin and on pushes
+        if: github.repository == 'readdy/readdy' && github.event_name == 'push'
+        env:
+          BINSTAR_TOKEN: ${{ secrets.BINSTAR_TOKEN }}
+        # if GITHUB_REF has tag then package is uploaded to normal anaconda channel
+        # if GITHUB_REF points to master then package is uploaded to dev channel
+        run: |
+          tools/ci/github/upload_conda_package.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ script:
 - conda install conda-verify
 - conda build -c defaults -c conda-forge tools/conda-recipe --python=$CONDA_PY
 
-after_success:
-- tools/ci/travis/upload_conda_package.sh
-- tools/ci/travis/make_docs.sh
+#after_success:
+#- tools/ci/travis/upload_conda_package.sh
+#- tools/ci/travis/make_docs.sh
 
 notifications:
   email: false

--- a/tools/ci/github/upload_conda_package.sh
+++ b/tools/ci/github/upload_conda_package.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Uploading the package requires:
+# - An already built conda package
+# - A binstar token stored in envvar BINSTAR_TOKEN
+# - A git ref stored in GITHUB_REF (provided by GitHub Actions)
+#   pointing either to the head of a branch or to a tag
+
+set -e -u
+
+function resolve_github_ref() {
+  tag="notag"
+  branch="none"
+  if [[ "${GITHUB_REF}" == "refs/heads/"* ]]; then
+    branch=${GITHUB_REF:11}
+    echo "GITHUB_REF ${GITHUB_REF} points to the head of branch ${branch}. There is no tag."
+  elif [[ "${GITHUB_REF}" == "refs/tags/"* ]]; then
+    tag=${GITHUB_REF:10}
+    echo "GITHUB_REF ${GITHUB_REF} points to the tag ${tag}. There is no branchname."
+  else
+    echo "Could not resolve GITHUB_REF=${GITHUB_REF}. Something is wrong."
+    exit 1
+  fi
+}
+
+# catch the case when there is no tag and the branch is not master
+function validate_this_should_run() {
+  if [ -z ${BINSTAR_TOKEN+x} ]; then
+    echo "BINSTAR_TOKEN was not set, so this is probably a fork. Exit."
+    exit 0
+  fi
+
+  if [ -z ${GITHUB_REF+x} ]; then
+    echo "GITHUB_REF was not set. Something is wrong."
+    exit 1
+  fi
+
+  resolve_github_ref
+
+  if [ "${tag}" == "notag" ] && [ "${branch}" != "master" ]; then
+    echo "When there is no tag, the branch must be master (is ${branch}). Exit."
+    exit 0
+  else
+    echo "O.K. There is no tag, but the branch is master."
+  fi
+}
+
+# fixme removethis: this is up here for debugging the build pipeline
+resolve_github_ref
+echo "tag is ${tag}"
+echo "branch is ${branch}"
+
+validate_this_should_run
+
+conda_package_file=$(conda build tools/conda-recipe --output | grep '.tar.bz2' | tail -1)
+echo "Found conda package file ${conda_package_file}"
+
+conda install anaconda-client -qy
+
+if [ "${tag}" == "notag" ]; then
+  echo "Uploading package ${conda_package_file} to dev channel"
+  anaconda -t "${BINSTAR_TOKEN}" upload -c readdy -u readdy -l dev --force "${conda_package_file}" > /dev/null 2>&1
+else
+  echo "Uploading tagged package ${conda_package_file} with tag ${tag} to regular channel"
+  anaconda -t "${BINSTAR_TOKEN}" upload -u readdy "${conda_package_file}" > /dev/null 2>&1
+fi
+
+echo "Uploaded. Done."


### PR DESCRIPTION
- Continuous integration via Github Actions, see `.github/workflows/ci.yml` (travis jobs were running into walltime of ~1h due to lengthy integration tests, [github jobs](https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions#usage-limits) can run up to 6 hours at the time of writing this)
- Uploading conda package is currently disabled/commented out for travis