### PR TITLE
Fix random number engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.6', '3.7', '3.8'] # used to build the conda package (not for miniconda installation)
     steps:
       - uses: actions/checkout@v2
-      - run: |
+      - if: github.repository == 'readdy/readdy' && github.event_name == 'push'
+        run: |
           git fetch --prune --unshallow
-      - run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - run: echo GITHUB_REF ${{github.ref}}
       - run: echo "$(git describe --always)"

--- a/include/readdy/model/RandomProvider.h
+++ b/include/readdy/model/RandomProvider.h
@@ -52,42 +52,42 @@
 
 namespace readdy::model::rnd {
 
-template<typename RealType=scalar, typename Generator = std::default_random_engine>
+template<typename RealType=scalar, typename Generator = std::mt19937>
 RealType normal(const RealType mean = 0.0, const RealType variance = 1.0) {
     static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
     std::normal_distribution<RealType> distribution(mean, variance);
     return distribution(generator);
 }
 
-template<typename RealType=scalar, typename Generator = std::default_random_engine>
+template<typename RealType=scalar, typename Generator = std::mt19937>
 RealType uniform_real(const RealType a = 0.0, const RealType b = 1.0) {
     static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
     std::uniform_real_distribution<RealType> distribution(a, b);
     return distribution(generator);
 }
 
-template<typename IntType=int, typename Generator = std::default_random_engine>
+template<typename IntType=int, typename Generator = std::mt19937>
 IntType uniform_int(const IntType a, const IntType b) {
     static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
     std::uniform_int_distribution<IntType> distribution(a, b);
     return distribution(generator);
 }
 
-template<typename RealType=scalar, typename Generator = std::default_random_engine>
+template<typename RealType=scalar, typename Generator = std::mt19937>
 RealType exponential(RealType lambda = 1.0) {
     static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
     std::exponential_distribution<RealType> distribution(lambda);
     return distribution(generator);
 }
 
-template<typename scalar, typename Generator = std::default_random_engine>
+template<typename scalar, typename Generator = std::mt19937>
 Vec3 normal3(const scalar mean = 0.0, const scalar variance = 1.0) {
     return {normal<scalar, Generator>(mean, variance),
             normal<scalar, Generator>(mean, variance),
             normal<scalar, Generator>(mean, variance)};
 }
 
-template<typename Iter, typename Gen = std::default_random_engine>
+template<typename Iter, typename Gen = std::mt19937>
 Iter random_element(Iter start, const Iter end) {
     using IntType = typename std::iterator_traits<Iter>::difference_type;
     std::advance(start, uniform_int<IntType, Gen>(0, std::distance(start, end)));

--- a/include/readdy/model/RandomProvider.h
+++ b/include/readdy/model/RandomProvider.h
@@ -52,30 +52,39 @@
 
 namespace readdy::model::rnd {
 
+template<typename Generator = std::mt19937>
+Generator randomlySeededGenerator() {
+    std::random_device r;
+    std::random_device::result_type threadId = std::hash<std::thread::id>()(std::this_thread::get_id());
+    std::random_device::result_type clck = clock();
+    std::seed_seq seed{threadId, r(), r(), clck, r(), r(), r(), r()};
+    return Generator(seed);
+}
+
 template<typename RealType=scalar, typename Generator = std::mt19937>
 RealType normal(const RealType mean = 0.0, const RealType variance = 1.0) {
-    static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
+    static thread_local auto generator = randomlySeededGenerator<Generator>();
     std::normal_distribution<RealType> distribution(mean, variance);
     return distribution(generator);
 }
 
 template<typename RealType=scalar, typename Generator = std::mt19937>
 RealType uniform_real(const RealType a = 0.0, const RealType b = 1.0) {
-    static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
+    static thread_local auto generator = randomlySeededGenerator<Generator>();
     std::uniform_real_distribution<RealType> distribution(a, b);
     return distribution(generator);
 }
 
 template<typename IntType=int, typename Generator = std::mt19937>
 IntType uniform_int(const IntType a, const IntType b) {
-    static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
+    static thread_local auto generator = randomlySeededGenerator<Generator>();
     std::uniform_int_distribution<IntType> distribution(a, b);
     return distribution(generator);
 }
 
 template<typename RealType=scalar, typename Generator = std::mt19937>
 RealType exponential(RealType lambda = 1.0) {
-    static thread_local Generator generator(clock() + std::hash<std::thread::id>()(std::this_thread::get_id()));
+    static thread_local auto generator = randomlySeededGenerator<Generator>();
     std::exponential_distribution<RealType> distribution(lambda);
     return distribution(generator);
 }


### PR DESCRIPTION
Fixes #180 

The `std::default_random_engine` defaults to a linear congruential engine with a period too small for stochastic simulations, thus fix the engine to mersenne twister engine.

The mt19937 has performance implications. In cases with many interactions the runtime should be dominated by neighborlist/force computations. But in a simulation without nonbonded interactions (e.g. a fixed topology diffusing) I've seen ~18% increase in runtime.

#### Before
![lcg](https://user-images.githubusercontent.com/5288581/79725798-0b31e980-82ea-11ea-9b1b-c1c35c2dc07b.png)

#### After
![mt19337](https://user-images.githubusercontent.com/5288581/79725831-19800580-82ea-11ea-834a-1e8242a7eda4.png)
