### PR TITLE
Observable refactoring and implementations for MPI Kernel

### DIFF
--- a/include/readdy/api/Saver.h
+++ b/include/readdy/api/Saver.h
@@ -103,6 +103,14 @@ public:
         return _checkpointTemplate;
     }
 
+    std::string describe() const {
+        std::string description;
+        description += fmt::format("   * base path: {}\n", basePath());
+        description += fmt::format("   * checkpoint filename template: {}\n", checkpointTemplate());
+        description += fmt::format("   * maximal number saves: {}\n", maxNSaves());
+        return description;
+    }
+
 private:
     std::string _basePath;
     std::size_t _maxNSaves;

--- a/include/readdy/api/Saver.h
+++ b/include/readdy/api/Saver.h
@@ -69,12 +69,12 @@ public:
         {
             model::observables::FlatTrajectory traj(kernel, 1, false);
             traj.enableWriteToFile(*file, "trajectory_ckpt", 1);
-            traj.callback(t);
+            traj.call(t);
         }
         {
             model::observables::Topologies tops(kernel, 1, false);
             tops.enableWriteToFile(*file, "topologies_ckpt", 1);
-            tops.callback(t);
+            tops.call(t);
         }
 
         while (_maxNSaves > 0 && previousCheckpoints.size() > _maxNSaves) {

--- a/include/readdy/api/Simulation.h
+++ b/include/readdy/api/Simulation.h
@@ -153,7 +153,7 @@ public:
      * @return an observable handle that allows for post-hoc modification of the observable
      */
     ObservableHandle registerObservable(std::unique_ptr<readdy::model::observables::ObservableBase> observable) {
-        _kernel->registerObservable(std::move(observable));
+        return _kernel->registerObservable(std::move(observable));
     }
 
     /**

--- a/include/readdy/api/Simulation.h
+++ b/include/readdy/api/Simulation.h
@@ -79,6 +79,9 @@ public:
     explicit Simulation(const std::string &kernel, model::Context ctx) : Simulation(
             plugin::KernelProvider::getInstance().create(kernel), std::move(ctx)) {};
 
+    /** Wrap a kernel with a working context in a simulation */
+    explicit Simulation(plugin::KernelProvider::kernel_ptr kernel) : _kernel(std::move(kernel)) {}
+
     /**
      * Creates a topology particle of a certain type at a position without adding it to the simulation box yet.
      * In order to instantiate it in the simulation it has to be used for creating a topology that owns this particular

--- a/include/readdy/api/Simulation.h
+++ b/include/readdy/api/Simulation.h
@@ -68,7 +68,7 @@ public:
     template<typename T>
     using observable_callback = typename std::function<void(typename T::result_type)>;
 
-    /** User provided context is copied, and no modifyable view on it is provided after construction of Simulation */
+    /** User provided context is copied, and no modifiable view on it is provided after construction of Simulation */
     explicit Simulation(plugin::KernelProvider::kernel_ptr kernel, model::Context ctx) : _kernel(std::move(kernel)) {
         _kernel->context() = std::move(ctx);
     }
@@ -148,43 +148,12 @@ public:
     }
 
     /**
-     * Registers a predefined observable with the kernel. A list of available observables can be obtained by
-     * getAvailableObservables().
-     * @tparam observable type
-     * @param observable the observable
-     * @return a uuid with which the observable is associated
-     */
-    template<typename T>
-    ObservableHandle registerObservable(std::unique_ptr<T> observable, detail::is_observable_type<T> * = 0) {
-        return registerObservable(std::move(observable), [](const typename T::result_type & /*unused*/) {});
-    }
-
-    /**
-     * Registers a predefined observable with the kernel together with a callback.
-     * A list of available observables can be obtained by getAvailableObservables().
-     * @tparam T observable type
+     * Registers a predefined observable with the kernel, which enables evaluation during the simulation.
      * @param observable the observable instance
-     * @param callback the callback
-     * @return a observable handle that allows for post-hoc modification of the observable
+     * @return an observable handle that allows for post-hoc modification of the observable
      */
-    template<typename T>
-    ObservableHandle registerObservable(std::unique_ptr<T> observable, const observable_callback<T> &callback,
-                                        detail::is_observable_type<T> * = 0) {
-        if (observable->type() == "Reactions") {
-            _kernel->context().recordReactionsWithPositions() = true;
-        } else if (observable->type() == "ReactionCounts") {
-            _kernel->context().recordReactionCounts() = true;
-        } else if (observable->type() == "Virial") {
-            _kernel->context().recordVirial() = true;
-        } else {
-            /* no action required */
-        }
-
-        auto connection = _kernel->connectObservable(observable.get());
-        observable->callback() = callback;
-        _observables.push_back(std::move(observable));
-        _observableConnections.push_back(std::move(connection));
-        return ObservableHandle{_observables.back().get()};
+    ObservableHandle registerObservable(std::unique_ptr<readdy::model::observables::ObservableBase> observable) {
+        _kernel->registerObservable(std::move(observable));
     }
 
     /**
@@ -192,7 +161,7 @@ public:
      * @param type the type
      * @return a vector containing the particle positions
      */
-    std::vector<Vec3> getParticlePositions(const std::string &type) {
+    [[nodiscard]] std::vector<Vec3> getParticlePositions(const std::string &type) {
         auto typeId = _kernel->context().particleTypes().idOf(type);
         const auto particles = _kernel->stateModel().getParticles();
         std::vector<Vec3> positions;
@@ -216,7 +185,8 @@ public:
     void addParticle(const std::string &type, scalar x, scalar y, scalar z) {
         const auto &s = context().boxSize();
         if (fabs(x) <= .5 * s[0] && fabs(y) <= .5 * s[1] && fabs(z) <= .5 * s[2]) {
-            _kernel->stateModel().addParticle({x, y, z, context().particleTypes().idOf(type)});
+            readdy::model::Particle p{x, y, z, context().particleTypes().idOf(type)};
+            _kernel->actions().addParticles(p)->perform();
         } else {
             log::error("particle position was not in bounds of the simulation box!");
         }
@@ -231,7 +201,7 @@ public:
     }
 
     /**
-     * Yields a nonmodifyable reference to the current context of this simulation.
+     * Yields a nonmodifiable reference to the current context of this simulation.
      * @return cref to the context
      */
     [[nodiscard]] const model::Context &context() const {
@@ -299,8 +269,6 @@ public:
 
 private:
     plugin::KernelProvider::kernel_ptr _kernel;
-    std::vector<std::unique_ptr<readdy::model::observables::ObservableBase>> _observables{};
-    std::vector<readdy::signals::scoped_connection> _observableConnections{};
 };
 
 }

--- a/include/readdy/kernel/singlecpu/actions/SCPUActionFactory.h
+++ b/include/readdy/kernel/singlecpu/actions/SCPUActionFactory.h
@@ -94,7 +94,8 @@ public:
 
     std::unique_ptr<readdy::model::actions::EvaluateObservables> evaluateObservables() const override;
 
-    std::unique_ptr<readdy::model::actions::MakeCheckpoint> makeCheckpoint(std::string base, std::size_t maxNSaves) const override;
+    std::unique_ptr<readdy::model::actions::MakeCheckpoint>
+    makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const override;
 
     std::unique_ptr<readdy::model::actions::InitializeKernel> initializeKernel() const override;
 

--- a/include/readdy/kernel/singlecpu/actions/SCPUMiscActions.h
+++ b/include/readdy/kernel/singlecpu/actions/SCPUMiscActions.h
@@ -63,10 +63,14 @@ private:
 
 class SCPUMakeCheckpoint : public readdy::model::actions::MakeCheckpoint {
 public:
-    SCPUMakeCheckpoint(SCPUKernel *kernel, const std::string& base, std::size_t maxNSaves) : kernel(kernel), saver(base, maxNSaves) {}
+    SCPUMakeCheckpoint(SCPUKernel *kernel, const std::string &base, std::size_t maxNSaves, const std::string &checkpointFormat) : kernel(kernel), saver(base, maxNSaves, checkpointFormat) {}
 
     void perform(TimeStep t) override {
         saver.makeCheckpoint(kernel, t);
+    }
+
+    std::string describe() const override {
+        return saver.describe();
     }
 private:
     SCPUKernel *kernel;

--- a/include/readdy/kernel/singlecpu/observables/SCPUObservableFactory.h
+++ b/include/readdy/kernel/singlecpu/observables/SCPUObservableFactory.h
@@ -34,10 +34,8 @@
 
 
 /**
- * << detailed description >>
- *
- * @file SingleCPUObservableFactory.h
- * @brief << brief description >>
+ * @file SCPUObservableFactory.h
+ * @brief Declaration of observable factory for single cpu kernel
  * @author clonker
  * @date 30.06.16
  */
@@ -50,36 +48,44 @@ class SCPUKernel;
 namespace observables {
 
 class SCPUObservableFactory : public readdy::model::observables::ObservableFactory {
-
 public:
     explicit SCPUObservableFactory(readdy::kernel::scpu::SCPUKernel* kernel);
 
-    std::unique_ptr<readdy::model::observables::Energy> energy(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Energy>
+    energy(Stride stride, ObsCallBack<readdy::model::observables::Energy> callBack) const override;
 
-    std::unique_ptr<readdy::model::observables::Virial> virial(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Virial>
+    virial(Stride stride, ObsCallBack<readdy::model::observables::Virial> callBack) const override;
 
-    std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
     histogramAlongAxis(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typesToCount,
-                       unsigned int axis) const override;
+                       unsigned int axis, ObsCallBack<readdy::model::observables::HistogramAlongAxis> callBack) const override;
 
-    std::unique_ptr<readdy::model::observables::NParticles>
-    nParticles(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::NParticles>
+    nParticles(Stride stride, std::vector<std::string> typesToCount,
+               ObsCallBack<readdy::model::observables::NParticles> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Forces>
-    forces(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Forces>
+    forces(Stride stride, std::vector<std::string> typesToCount,
+           ObsCallBack<readdy::model::observables::Forces> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Positions>
-    positions(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Positions>
+    positions(Stride stride, std::vector<std::string> typesToCount,
+              ObsCallBack<readdy::model::observables::Positions> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::RadialDistribution>
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::RadialDistribution>
     radialDistribution(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typeCountFrom,
-                       std::vector<std::string> typeCountTo, scalar particleDensity) const override;
+                       std::vector<std::string> typeCountTo, scalar particleDensity,
+                       ObsCallBack<readdy::model::observables::RadialDistribution> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Particles> particles(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Particles>
+    particles(Stride stride, ObsCallBack<readdy::model::observables::Particles> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Reactions> reactions(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Reactions>
+    reactions(Stride stride, ObsCallBack<readdy::model::observables::Reactions> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::ReactionCounts> reactionCounts(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::ReactionCounts>
+    reactionCounts(Stride stride, ObsCallBack<readdy::model::observables::ReactionCounts> callback) const override;
 private:
     readdy::kernel::scpu::SCPUKernel *const kernel;
 };

--- a/include/readdy/kernel/singlecpu/observables/SCPUObservableFactory.h
+++ b/include/readdy/kernel/singlecpu/observables/SCPUObservableFactory.h
@@ -52,40 +52,40 @@ public:
     explicit SCPUObservableFactory(readdy::kernel::scpu::SCPUKernel* kernel);
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Energy>
-    energy(Stride stride, ObsCallBack<readdy::model::observables::Energy> callBack) const override;
+    energy(Stride stride, ObsCallback<readdy::model::observables::Energy> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Virial>
-    virial(Stride stride, ObsCallBack<readdy::model::observables::Virial> callBack) const override;
+    virial(Stride stride, ObsCallback<readdy::model::observables::Virial> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
     histogramAlongAxis(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typesToCount,
-                       unsigned int axis, ObsCallBack<readdy::model::observables::HistogramAlongAxis> callBack) const override;
+                       unsigned int axis, ObsCallback<readdy::model::observables::HistogramAlongAxis> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::NParticles>
     nParticles(Stride stride, std::vector<std::string> typesToCount,
-               ObsCallBack<readdy::model::observables::NParticles> callback) const override;
+               ObsCallback<readdy::model::observables::NParticles> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Forces>
     forces(Stride stride, std::vector<std::string> typesToCount,
-           ObsCallBack<readdy::model::observables::Forces> callback) const override;
+           ObsCallback<readdy::model::observables::Forces> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Positions>
     positions(Stride stride, std::vector<std::string> typesToCount,
-              ObsCallBack<readdy::model::observables::Positions> callback) const override;
+              ObsCallback<readdy::model::observables::Positions> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::RadialDistribution>
     radialDistribution(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typeCountFrom,
                        std::vector<std::string> typeCountTo, scalar particleDensity,
-                       ObsCallBack<readdy::model::observables::RadialDistribution> callback) const override;
+                       ObsCallback<readdy::model::observables::RadialDistribution> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Particles>
-    particles(Stride stride, ObsCallBack<readdy::model::observables::Particles> callback) const override;
+    particles(Stride stride, ObsCallback<readdy::model::observables::Particles> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Reactions>
-    reactions(Stride stride, ObsCallBack<readdy::model::observables::Reactions> callback) const override;
+    reactions(Stride stride, ObsCallback<readdy::model::observables::Reactions> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::ReactionCounts>
-    reactionCounts(Stride stride, ObsCallBack<readdy::model::observables::ReactionCounts> callback) const override;
+    reactionCounts(Stride stride, ObsCallback<readdy::model::observables::ReactionCounts> callback) const override;
 private:
     readdy::kernel::scpu::SCPUKernel *const kernel;
 };

--- a/include/readdy/model/actions/ActionFactory.h
+++ b/include/readdy/model/actions/ActionFactory.h
@@ -128,7 +128,6 @@ public:
     virtual std::unique_ptr<MakeCheckpoint> makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const = 0;
 
     virtual std::unique_ptr<InitializeKernel> initializeKernel() const = 0;
-
 };
 
 }

--- a/include/readdy/model/actions/ActionFactory.h
+++ b/include/readdy/model/actions/ActionFactory.h
@@ -125,7 +125,7 @@ public:
 
     virtual std::unique_ptr<EvaluateObservables> evaluateObservables() const = 0;
 
-    virtual std::unique_ptr<MakeCheckpoint> makeCheckpoint(std::string base, std::size_t maxNSaves) const = 0;
+    virtual std::unique_ptr<MakeCheckpoint> makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const = 0;
 
     virtual std::unique_ptr<InitializeKernel> initializeKernel() const = 0;
 

--- a/include/readdy/model/actions/Actions.h
+++ b/include/readdy/model/actions/Actions.h
@@ -380,6 +380,7 @@ class MakeCheckpoint {
 public:
     virtual void perform(TimeStep t) = 0;
     virtual ~MakeCheckpoint() = default;
+    virtual std::string describe() const = 0;
 };
 
 template<typename T>

--- a/include/readdy/model/actions/Actions.h
+++ b/include/readdy/model/actions/Actions.h
@@ -70,6 +70,7 @@
 #include <readdy/common/index_persistent_vector.h>
 #include "Utils.h"
 #include <readdy/model/topologies/GraphTopology.h>
+#include <readdy/api/ObservableHandle.h>
 
 #if READDY_OSX || READDY_WINDOWS
 #include <functional>

--- a/include/readdy/model/observables/Energy.h
+++ b/include/readdy/model/observables/Energy.h
@@ -69,14 +69,14 @@ public:
 
     std::string_view type() const override;
 
-private:
-    struct Impl;
-    std::unique_ptr<Impl> pimpl;
-
+protected:
     void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 
     void append() override;
 
+private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
 };
 
 }

--- a/include/readdy/model/observables/Observable.h
+++ b/include/readdy/model/observables/Observable.h
@@ -126,11 +126,11 @@ public:
     virtual ~ObservableBase() = default;
 
     /**
-     * Method that will trigger a callback with the current results if shouldExecuteCall() is true.
+     * Method that will trigger a callback with the current results if shouldEvaluate() is true.
      * @param t
      */
     virtual void call(TimeStep t) {
-        if (shouldExecuteCall(t)) {
+        if (shouldEvaluate(t)) {
             firstCall = false;
             t_current = t;
             evaluate();
@@ -143,12 +143,12 @@ public:
      * @param t the time step
      * @return true, if we haven't been evaluated in the current time step yet and stride is 0 or a divisor of t
      */
-    virtual bool shouldExecuteCall(TimeStep t) const {
+    virtual bool shouldEvaluate(TimeStep t) const {
         return (t_current != t || firstCall) && (_stride == 0 || t % _stride == 0);
     }
 
     /**
-     * Will be called automagically when shouldExecuteCall() is true. Can also be called manually and will then
+     * Will be called automagically when shouldEvaluate() is true. Can also be called manually and will then
      * place the observable's results into the result member (in case of a readdy::model::Observable),
      * based on the current state of the system.
      */
@@ -270,12 +270,12 @@ public:
     }
 
     /**
-     * Function that will evaluate the observable and trigger a callback if ObservableBase#shouldExecuteCall()
+     * Function that will evaluate the observable and trigger a callback if ObservableBase#shouldEvaluate()
      * is true.
      * @param t the time step
      */
     void call(TimeStep t) override {
-        if (shouldExecuteCall(t)) {
+        if (shouldEvaluate(t)) {
             ObservableBase::call(t);
             _callback(result);
         }
@@ -319,12 +319,12 @@ public:
             : Observable<RESULT>(kernel, stride), parentObservables(std::forward<PARENT_OBS *>(parents)...) {}
 
     /**
-     * If ObservableBase#shouldExecuteCall() is true, this will call the Observable#callback() function
+     * If ObservableBase#shouldEvaluate() is true, this will call the Observable#callback() function
      * for each of its parents.
      * @param t the current time
      */
     void callback(TimeStep t) override {
-        if (ObservableBase::shouldExecuteCall(t)) {
+        if (ObservableBase::shouldEvaluate(t)) {
             readdy::util::for_each_in_tuple(parentObservables, CallbackFunctor(ObservableBase::t_current));
             ObservableBase::call(t);
         }

--- a/kernels/cpu/include/readdy/kernel/cpu/actions/CPUActionFactory.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/CPUActionFactory.h
@@ -87,7 +87,8 @@ public:
 
     std::unique_ptr<model::actions::EvaluateObservables> evaluateObservables() const override;
 
-    std::unique_ptr<model::actions::MakeCheckpoint> makeCheckpoint(std::string base, std::size_t maxNSaves) const override;
+    std::unique_ptr<model::actions::MakeCheckpoint>
+    makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const override;
 
     std::unique_ptr<model::actions::InitializeKernel> initializeKernel() const override;
 };

--- a/kernels/cpu/include/readdy/kernel/cpu/actions/CPUMiscActions.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/actions/CPUMiscActions.h
@@ -62,10 +62,16 @@ private:
 
 class CPUMakeCheckpoint : public readdy::model::actions::MakeCheckpoint {
 public:
-    CPUMakeCheckpoint(CPUKernel *kernel, const std::string& base, std::size_t maxNSaves) : kernel(kernel), saver(base, maxNSaves) {}
+    CPUMakeCheckpoint(CPUKernel *kernel, const std::string &base, std::size_t maxNSaves,
+                      const std::string &checkpointFormat)
+                      : kernel(kernel), saver(base, maxNSaves, checkpointFormat) {}
 
     void perform(TimeStep t) override {
         saver.makeCheckpoint(kernel, t);
+    }
+
+    std::string describe() const override {
+        return saver.describe();
     }
 private:
     CPUKernel *kernel;

--- a/kernels/cpu/include/readdy/kernel/cpu/observables/CPUObservableFactory.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/observables/CPUObservableFactory.h
@@ -54,39 +54,39 @@ public:
     explicit CPUObservableFactory(CPUKernel* kernel);
 
     [[nodiscard]] std::unique_ptr<model::observables::Energy>
-    energy(Stride stride, ObsCallBack <model::observables::Energy> callback) const override;
+    energy(Stride stride, ObsCallback <model::observables::Energy> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::Virial>
-    virial(Stride stride, ObsCallBack <model::observables::Virial> callback) const override;
+    virial(Stride stride, ObsCallback <model::observables::Virial> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::HistogramAlongAxis>
     histogramAlongAxis(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typesToCount,
-                       unsigned int axis, ObsCallBack <model::observables::HistogramAlongAxis> callback) const override;
+                       unsigned int axis, ObsCallback <model::observables::HistogramAlongAxis> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::NParticles>
     nParticles(Stride stride, std::vector<std::string> typesToCount,
-               ObsCallBack <model::observables::NParticles> callback) const override;
+               ObsCallback <model::observables::NParticles> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::Forces>
     forces(Stride stride, std::vector<std::string> typesToCount,
-           ObsCallBack <model::observables::Forces> callback) const override;
+           ObsCallback <model::observables::Forces> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::Positions>
-    positions(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<model::observables::Positions> callback) const override;
+    positions(Stride stride, std::vector<std::string> typesToCount, ObsCallback<model::observables::Positions> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::RadialDistribution>
     radialDistribution(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typeCountFrom,
                        std::vector<std::string> typeCountTo, scalar particleDensity,
-                       ObsCallBack<model::observables::RadialDistribution> callback) const override;
+                       ObsCallback<model::observables::RadialDistribution> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::Particles>
-    particles(Stride stride, ObsCallBack<model::observables::Particles> callback) const override;
+    particles(Stride stride, ObsCallback<model::observables::Particles> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::Reactions>
-    reactions(Stride stride, ObsCallBack<model::observables::Reactions> callback) const override;
+    reactions(Stride stride, ObsCallback<model::observables::Reactions> callback) const override;
 
     [[nodiscard]] std::unique_ptr<model::observables::ReactionCounts>
-    reactionCounts(Stride stride, ObsCallBack<model::observables::ReactionCounts> callback) const override;
+    reactionCounts(Stride stride, ObsCallback<model::observables::ReactionCounts> callback) const override;
 
 private:
     CPUKernel *const kernel;

--- a/kernels/cpu/include/readdy/kernel/cpu/observables/CPUObservableFactory.h
+++ b/kernels/cpu/include/readdy/kernel/cpu/observables/CPUObservableFactory.h
@@ -34,10 +34,8 @@
 
 
 /**
- * << detailed description >>
- *
  * @file ObservableFactory.h
- * @brief << brief description >>
+ * @brief Declaration of the observable factory for the CPU kernel
  * @author clonker
  * @date 21.07.16
  */
@@ -55,32 +53,40 @@ class CPUObservableFactory : public readdy::model::observables::ObservableFactor
 public:
     explicit CPUObservableFactory(CPUKernel* kernel);
 
-    std::unique_ptr<model::observables::Energy> energy(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::Energy>
+    energy(Stride stride, ObsCallBack <model::observables::Energy> callback) const override;
 
-    std::unique_ptr<model::observables::Virial> virial(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::Virial>
+    virial(Stride stride, ObsCallBack <model::observables::Virial> callback) const override;
 
-    std::unique_ptr<model::observables::HistogramAlongAxis>
+    [[nodiscard]] std::unique_ptr<model::observables::HistogramAlongAxis>
     histogramAlongAxis(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typesToCount,
-                       unsigned int axis) const override;
+                       unsigned int axis, ObsCallBack <model::observables::HistogramAlongAxis> callback) const override;
 
-    std::unique_ptr<model::observables::NParticles>
-    nParticles(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::NParticles>
+    nParticles(Stride stride, std::vector<std::string> typesToCount,
+               ObsCallBack <model::observables::NParticles> callback) const override;
 
-    std::unique_ptr<model::observables::Forces>
-    forces(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::Forces>
+    forces(Stride stride, std::vector<std::string> typesToCount,
+           ObsCallBack <model::observables::Forces> callback) const override;
 
-    std::unique_ptr<model::observables::Positions>
-    positions(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::Positions>
+    positions(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<model::observables::Positions> callback) const override;
 
-    std::unique_ptr<model::observables::RadialDistribution>
+    [[nodiscard]] std::unique_ptr<model::observables::RadialDistribution>
     radialDistribution(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typeCountFrom,
-                       std::vector<std::string> typeCountTo, scalar particleDensity) const override;
+                       std::vector<std::string> typeCountTo, scalar particleDensity,
+                       ObsCallBack<model::observables::RadialDistribution> callback) const override;
 
-    std::unique_ptr<model::observables::Particles> particles(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::Particles>
+    particles(Stride stride, ObsCallBack<model::observables::Particles> callback) const override;
 
-    std::unique_ptr<model::observables::Reactions> reactions(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::Reactions>
+    reactions(Stride stride, ObsCallBack<model::observables::Reactions> callback) const override;
 
-    std::unique_ptr<model::observables::ReactionCounts> reactionCounts(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<model::observables::ReactionCounts>
+    reactionCounts(Stride stride, ObsCallBack<model::observables::ReactionCounts> callback) const override;
 
 private:
     CPUKernel *const kernel;

--- a/kernels/cpu/src/actions/CPUActionFactory.cpp
+++ b/kernels/cpu/src/actions/CPUActionFactory.cpp
@@ -123,8 +123,8 @@ std::unique_ptr<model::actions::EvaluateObservables> CPUActionFactory::evaluateO
 }
 
 std::unique_ptr<model::actions::MakeCheckpoint>
-CPUActionFactory::makeCheckpoint(std::string base, std::size_t maxNSaves) const {
-    return {std::make_unique<CPUMakeCheckpoint>(kernel, base, maxNSaves)};
+CPUActionFactory::makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const {
+    return {std::make_unique<CPUMakeCheckpoint>(kernel, base, maxNSaves, checkpointFormat)};
 }
 
 std::unique_ptr<model::actions::InitializeKernel> CPUActionFactory::initializeKernel() const {

--- a/kernels/cpu/src/observables/CPUObservableFactory.cpp
+++ b/kernels/cpu/src/observables/CPUObservableFactory.cpp
@@ -56,7 +56,7 @@ std::unique_ptr<model::observables::HistogramAlongAxis>
 CPUObservableFactory::histogramAlongAxis(Stride stride, std::vector<scalar> binBorders,
                                          std::vector<std::string> typesToCount,
                                          unsigned int axis,
-                                         ObsCallBack <model::observables::HistogramAlongAxis> callback) const {
+                                         ObsCallback <model::observables::HistogramAlongAxis> callback) const {
     auto obs = std::make_unique<CPUHistogramAlongAxis>(kernel, stride, binBorders, typesToCount, axis);
     obs->setCallback(callback);
     return std::move(obs);
@@ -64,7 +64,7 @@ CPUObservableFactory::histogramAlongAxis(Stride stride, std::vector<scalar> binB
 
 std::unique_ptr<model::observables::NParticles>
 CPUObservableFactory::nParticles(Stride stride, std::vector<std::string> typesToCount,
-                                 ObsCallBack <model::observables::NParticles> callback) const {
+                                 ObsCallback <model::observables::NParticles> callback) const {
     auto obs = std::make_unique<CPUNParticles>(kernel, stride, typesToCount);
     obs->setCallback(callback);
     return std::move(obs);
@@ -72,7 +72,7 @@ CPUObservableFactory::nParticles(Stride stride, std::vector<std::string> typesTo
 
 std::unique_ptr<model::observables::Forces>
 CPUObservableFactory::forces(Stride stride, std::vector<std::string> typesToCount,
-                             ObsCallBack <model::observables::Forces> callback) const {
+                             ObsCallback <model::observables::Forces> callback) const {
     auto obs = std::make_unique<CPUForces>(kernel, stride, typesToCount);
     obs->setCallback(callback);
     return std::move(obs);
@@ -80,7 +80,7 @@ CPUObservableFactory::forces(Stride stride, std::vector<std::string> typesToCoun
 
 std::unique_ptr<model::observables::Positions>
 CPUObservableFactory::positions(Stride stride, std::vector<std::string> typesToCount,
-                                model::observables::ObservableFactory::ObsCallBack <model::observables::Positions> callback) const {
+                                model::observables::ObservableFactory::ObsCallback <model::observables::Positions> callback) const {
     auto obs = std::make_unique<CPUPositions>(kernel, stride, typesToCount);
     obs->setCallback(callback);
     return std::move(obs);
@@ -90,7 +90,7 @@ std::unique_ptr<model::observables::RadialDistribution>
 CPUObservableFactory::radialDistribution(Stride stride, std::vector<scalar> binBorders,
                                          std::vector<std::string> typeCountFrom,
                                          std::vector<std::string> typeCountTo, scalar particleDensity,
-                                         model::observables::ObservableFactory::ObsCallBack <model::observables::RadialDistribution> callback) const {
+                                         model::observables::ObservableFactory::ObsCallback <model::observables::RadialDistribution> callback) const {
     auto obs = std::make_unique<model::observables::RadialDistribution>(
             kernel, stride, binBorders, typeCountFrom, typeCountTo, particleDensity
     );
@@ -99,14 +99,14 @@ CPUObservableFactory::radialDistribution(Stride stride, std::vector<scalar> binB
 }
 
 std::unique_ptr<model::observables::Particles> CPUObservableFactory::particles(Stride stride,
-                                                           model::observables::ObservableFactory::ObsCallBack <model::observables::Particles> callback) const {
+                                                           model::observables::ObservableFactory::ObsCallback <model::observables::Particles> callback) const {
     auto obs = std::make_unique<CPUParticles>(kernel, stride);
     obs->setCallback(callback);
     return std::move(obs);
 }
 
 std::unique_ptr<model::observables::Reactions>
-CPUObservableFactory::reactions(Stride stride, ObsCallBack <model::observables::Reactions> callback) const {
+CPUObservableFactory::reactions(Stride stride, ObsCallback <model::observables::Reactions> callback) const {
     auto obs = std::make_unique<CPUReactions>(kernel, stride);
     obs->setCallback(callback);
     kernel->context().recordReactionsWithPositions() = true;
@@ -114,7 +114,7 @@ CPUObservableFactory::reactions(Stride stride, ObsCallBack <model::observables::
 }
 
 std::unique_ptr<model::observables::ReactionCounts>
-CPUObservableFactory::reactionCounts(Stride stride, ObsCallBack <model::observables::ReactionCounts> callback) const {
+CPUObservableFactory::reactionCounts(Stride stride, ObsCallback <model::observables::ReactionCounts> callback) const {
     auto obs = std::make_unique<CPUReactionCounts>(kernel, stride);
     obs->setCallback(callback);
     kernel->context().recordReactionCounts() = true;
@@ -122,7 +122,7 @@ CPUObservableFactory::reactionCounts(Stride stride, ObsCallBack <model::observab
 }
 
 std::unique_ptr<model::observables::Virial>
-CPUObservableFactory::virial(Stride stride, ObsCallBack <model::observables::Virial> callback) const {
+CPUObservableFactory::virial(Stride stride, ObsCallback <model::observables::Virial> callback) const {
     auto obs = std::make_unique<CPUVirial>(kernel, stride);
     obs->setCallback(callback);
     kernel->context().recordVirial() = true;
@@ -130,7 +130,7 @@ CPUObservableFactory::virial(Stride stride, ObsCallBack <model::observables::Vir
 }
 
 std::unique_ptr<model::observables::Energy>
-CPUObservableFactory::energy(Stride stride, ObsCallBack <model::observables::Energy> callback) const {
+CPUObservableFactory::energy(Stride stride, ObsCallback <model::observables::Energy> callback) const {
     auto obs = std::make_unique<model::observables::Energy>(kernel, stride);
     obs->setCallback(callback);
     return std::move(obs);

--- a/kernels/cpu/src/observables/CPUObservableFactory.cpp
+++ b/kernels/cpu/src/observables/CPUObservableFactory.cpp
@@ -54,53 +54,86 @@ CPUObservableFactory::CPUObservableFactory(CPUKernel *const kernel) : readdy::mo
 
 std::unique_ptr<model::observables::HistogramAlongAxis>
 CPUObservableFactory::histogramAlongAxis(Stride stride, std::vector<scalar> binBorders,
-                                         std::vector<std::string> typesToCount, unsigned int axis) const {
-    return {std::make_unique<CPUHistogramAlongAxis>(kernel, stride, binBorders, typesToCount, axis)};
+                                         std::vector<std::string> typesToCount,
+                                         unsigned int axis,
+                                         ObsCallBack <model::observables::HistogramAlongAxis> callback) const {
+    auto obs = std::make_unique<CPUHistogramAlongAxis>(kernel, stride, binBorders, typesToCount, axis);
+    obs->setCallback(callback);
+    return std::move(obs);
 }
 
 std::unique_ptr<model::observables::NParticles>
-CPUObservableFactory::nParticles(Stride stride, std::vector<std::string> typesToCount) const {
-    return {std::make_unique<CPUNParticles>(kernel, stride, typesToCount)};
+CPUObservableFactory::nParticles(Stride stride, std::vector<std::string> typesToCount,
+                                 ObsCallBack <model::observables::NParticles> callback) const {
+    auto obs = std::make_unique<CPUNParticles>(kernel, stride, typesToCount);
+    obs->setCallback(callback);
+    return std::move(obs);
 }
 
 std::unique_ptr<model::observables::Forces>
-CPUObservableFactory::forces(Stride stride, std::vector<std::string> typesToCount) const {
-    return {std::make_unique<CPUForces>(kernel, stride, typesToCount)};
+CPUObservableFactory::forces(Stride stride, std::vector<std::string> typesToCount,
+                             ObsCallBack <model::observables::Forces> callback) const {
+    auto obs = std::make_unique<CPUForces>(kernel, stride, typesToCount);
+    obs->setCallback(callback);
+    return std::move(obs);
 }
 
 std::unique_ptr<model::observables::Positions>
-CPUObservableFactory::positions(Stride stride, std::vector<std::string> typesToCount) const {
-    return {std::make_unique<CPUPositions>(kernel, stride, typesToCount)};
+CPUObservableFactory::positions(Stride stride, std::vector<std::string> typesToCount,
+                                model::observables::ObservableFactory::ObsCallBack <model::observables::Positions> callback) const {
+    auto obs = std::make_unique<CPUPositions>(kernel, stride, typesToCount);
+    obs->setCallback(callback);
+    return std::move(obs);
 }
 
 std::unique_ptr<model::observables::RadialDistribution>
 CPUObservableFactory::radialDistribution(Stride stride, std::vector<scalar> binBorders,
-                                         std::vector<std::string> typeCountFrom, std::vector<std::string> typeCountTo,
-                                         scalar particleDensity) const {
-    return {std::make_unique<model::observables::RadialDistribution>(
+                                         std::vector<std::string> typeCountFrom,
+                                         std::vector<std::string> typeCountTo, scalar particleDensity,
+                                         model::observables::ObservableFactory::ObsCallBack <model::observables::RadialDistribution> callback) const {
+    auto obs = std::make_unique<model::observables::RadialDistribution>(
             kernel, stride, binBorders, typeCountFrom, typeCountTo, particleDensity
-    )};
+    );
+    obs->setCallback(callback);
+    return std::move(obs);
 }
 
-std::unique_ptr<model::observables::Particles> CPUObservableFactory::particles(Stride stride) const {
-    return {std::make_unique<CPUParticles>(kernel, stride)};
+std::unique_ptr<model::observables::Particles> CPUObservableFactory::particles(Stride stride,
+                                                           model::observables::ObservableFactory::ObsCallBack <model::observables::Particles> callback) const {
+    auto obs = std::make_unique<CPUParticles>(kernel, stride);
+    obs->setCallback(callback);
+    return std::move(obs);
 }
 
-std::unique_ptr<model::observables::Reactions> CPUObservableFactory::reactions(Stride stride) const {
-    return {std::make_unique<CPUReactions>(kernel, stride)};
+std::unique_ptr<model::observables::Reactions>
+CPUObservableFactory::reactions(Stride stride, ObsCallBack <model::observables::Reactions> callback) const {
+    auto obs = std::make_unique<CPUReactions>(kernel, stride);
+    obs->setCallback(callback);
+    kernel->context().recordReactionsWithPositions() = true;
+    return std::move(obs);
 }
 
-std::unique_ptr<model::observables::ReactionCounts> CPUObservableFactory::reactionCounts(Stride stride) const {
-    return {std::make_unique<CPUReactionCounts>(kernel, stride)};
+std::unique_ptr<model::observables::ReactionCounts>
+CPUObservableFactory::reactionCounts(Stride stride, ObsCallBack <model::observables::ReactionCounts> callback) const {
+    auto obs = std::make_unique<CPUReactionCounts>(kernel, stride);
+    obs->setCallback(callback);
+    kernel->context().recordReactionCounts() = true;
+    return std::move(obs);
 }
 
 std::unique_ptr<model::observables::Virial>
-CPUObservableFactory::virial(Stride stride) const {
-    return {std::make_unique<CPUVirial>(kernel, stride)};
+CPUObservableFactory::virial(Stride stride, ObsCallBack <model::observables::Virial> callback) const {
+    auto obs = std::make_unique<CPUVirial>(kernel, stride);
+    obs->setCallback(callback);
+    kernel->context().recordVirial() = true;
+    return std::move(obs);
 }
 
-std::unique_ptr<model::observables::Energy> CPUObservableFactory::energy(Stride stride) const {
-    return {std::make_unique<model::observables::Energy>(kernel, stride)};
+std::unique_ptr<model::observables::Energy>
+CPUObservableFactory::energy(Stride stride, ObsCallBack <model::observables::Energy> callback) const {
+    auto obs = std::make_unique<model::observables::Energy>(kernel, stride);
+    obs->setCallback(callback);
+    return std::move(obs);
 }
 
 }

--- a/kernels/cpu/test/TestNeighborList.cpp
+++ b/kernels/cpu/test/TestNeighborList.cpp
@@ -193,9 +193,9 @@ TEST_CASE("Test cpu neighbor list", "[cpu]") {
         }
 
         auto obs = kernel->observe().nParticles(1, std::vector<std::string>({"F", "A"}));
-        obs->callback() = [&](const readdy::model::observables::NParticles::result_type &result) {
+        obs->setCallback([&](const readdy::model::observables::NParticles::result_type &result) {
             REQUIRE(result[0] == 100);
-        };
+        });
         auto connection = kernel->connectObservable(obs.get());
 
         {
@@ -225,7 +225,7 @@ TEST_CASE("Test cpu neighbor list", "[cpu]") {
             kernel->addParticle("A", n3(0., 1.));
         }
         auto obs = kernel->observe().nParticles(1);
-        obs->callback() = (
+        obs->setCallback(
                 [&](const readdy::model::observables::NParticles::result_type &) {
                     const auto neighbor_list = kernel->getCPUKernelStateModel().getNeighborList();
 

--- a/kernels/cpu/test/TestReactions.cpp
+++ b/kernels/cpu/test/TestReactions.cpp
@@ -227,9 +227,6 @@ TEST_CASE("Test cpu kernel reaction handling", "[cpu]") {
         auto &&reactions = kernel->actions().gillespie(1);
 
         auto pp_obs = kernel->observe().positions(1);
-        pp_obs->callback() = ([](const readdy::model::observables::Positions::result_type &t) {
-            /* ignore */
-        });
         auto connection = kernel->connectObservable(pp_obs.get());
 
         const int n_particles = 200;

--- a/kernels/mpi/include/readdy/kernel/mpi/MPIKernel.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/MPIKernel.h
@@ -78,6 +78,9 @@ public:
     // factory method
     static readdy::model::Kernel *create();
 
+    // factory method with context
+    static readdy::model::Kernel *create(const readdy::model::Context &);
+
     const MPIStateModel &getMPIKernelStateModel() const {
         return _stateModel;
     }

--- a/kernels/mpi/include/readdy/kernel/mpi/MPIKernel.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/MPIKernel.h
@@ -133,6 +133,12 @@ public:
         return _commUsedRanks;
     }
 
+    virtual void evaluateObservables(TimeStep t) override {
+        if (not _domain.isIdleRank()) {
+            _signal(t);
+        }
+    }
+
 protected:
     // order here is order of initialization
     // https://en.cppreference.com/w/cpp/language/initializer_list#Initialization_order

--- a/kernels/mpi/include/readdy/kernel/mpi/MPIStateModel.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/MPIStateModel.h
@@ -209,6 +209,10 @@ public:
         return _commUsedRanks;
     }
 
+    const MPI_Comm &commUsedRanks() const {
+        return _commUsedRanks;
+    }
+
     /**
      * Above are individual operations, i.e. each worker/rank, can execute them without side-effects.
      * Following are MPI collective operations, i.e. behavior is different depending on rank.

--- a/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActionFactory.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActionFactory.h
@@ -91,7 +91,7 @@ public:
     [[nodiscard]] std::unique_ptr<readdy::model::actions::EvaluateObservables> evaluateObservables() const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::actions::MakeCheckpoint>
-    makeCheckpoint(std::string base, std::size_t maxNSaves) const override;
+    makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::actions::InitializeKernel> initializeKernel() const override;
 };

--- a/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActions.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActions.h
@@ -184,7 +184,9 @@ private:
 
 class MPIMakeCheckpoint : public readdy::model::actions::MakeCheckpoint {
 public:
-    MPIMakeCheckpoint(MPIKernel *kernel, const std::string& base, std::size_t maxNSaves) : kernel(kernel), saver(base, maxNSaves) {}
+    MPIMakeCheckpoint(MPIKernel *kernel, const std::string& base, std::size_t maxNSaves,
+                      const std::string &checkpointFormat)
+            : kernel(kernel), saver(base, maxNSaves, checkpointFormat) {}
 
     void perform(TimeStep t) override {
         // todo sync (MPIGather) the state to master's stateModel, then makeCheckpoint as usual and clear stateModel
@@ -199,6 +201,10 @@ public:
         } else {
             // no op for idlers
         }
+    }
+
+    std::string describe() const override {
+        return saver.describe();
     }
 private:
     MPIKernel *kernel;

--- a/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActions.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActions.h
@@ -100,6 +100,13 @@ private:
     void performImpl();
 };
 
+/** no-op but needed to run the default simulation loop */
+class MPICreateNeighborList : public readdy::model::actions::CreateNeighborList {
+public:
+    MPICreateNeighborList(MPIKernel *kernel) : CreateNeighborList(kernel->context().calculateMaxCutoff()) {}
+    void perform() override {/* no-op, this neighborlist is initialized by construction */}
+};
+
 class MPIUpdateNeighborList : public readdy::model::actions::UpdateNeighborList {
 public:
     explicit MPIUpdateNeighborList(MPIKernel *kernel) : UpdateNeighborList(), kernel(kernel) {}
@@ -114,6 +121,13 @@ public:
 
 private:
     MPIKernel *const kernel;
+};
+
+/** no-op but needed to run the default simulation loop */
+class MPIClearNeighborList : public readdy::model::actions::ClearNeighborList {
+public:
+    explicit MPIClearNeighborList() : ClearNeighborList() {}
+    void perform() override {/* no-op */}
 };
 
 class MPIEvaluateCompartments : public readdy::model::actions::EvaluateCompartments {

--- a/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActions.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/actions/MPIActions.h
@@ -53,13 +53,15 @@ namespace readdy::kernel::mpi::actions {
 
 class MPIAddParticles : public readdy::model::actions::AddParticles {
 public:
-    MPIAddParticles(MPIKernel *kernel, const std::vector<readdy::model::Particle> &particles) : AddParticles(kernel, particles), kernel(kernel) {}
+    MPIAddParticles(MPIKernel *kernel, const std::vector<readdy::model::Particle> &particles)
+        : AddParticles(kernel, particles), kernel(kernel) {}
 
     void perform() override {
         if (kernel) {
             kernel->getMPIKernelStateModel().distributeParticles(particles);
         } else {
-            throw std::runtime_error("invalid kernel");
+            throw std::runtime_error(
+                    fmt::format("rank={} MPIAddParticles::perform invalid kernel", kernel->domain().rank()));
         }
     }
 private:

--- a/kernels/mpi/include/readdy/kernel/mpi/model/MPIParticleData.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/model/MPIParticleData.h
@@ -79,6 +79,7 @@ struct MPIEntry {
      * Usually is determined by position but not necessarily, it states which rank is responsible for this.
      * In evaluating forces and reactions it helps to know the rank without parsing the domain object (more deref).
      * Also the compound (rank, id) might provide a unique identifier if necessary (not planning to).
+     * Helpful when avoiding double counting of pair-interaction observables e.g. virial across domain boundaries.
      */
     int rank;
     /**

--- a/kernels/mpi/include/readdy/kernel/mpi/model/MPIUtils.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/model/MPIUtils.h
@@ -228,7 +228,7 @@ inline std::vector<T> gatherObjects(const std::vector<T> &objects, int root, con
     /// (1) find out how many each one sends. In principle the root can also send objects.
     int number = objects.size();
     std::vector<int> nPerRank(domain.nUsedRanks(), 0);
-    MPI_Gather(&number, 1, MPI_INT, nPerRank.data(), 1, MPI_INT, 0, comm);
+    MPI_Gather(&number, 1, MPI_INT, nPerRank.data(), 1, MPI_INT, root, comm);
 
     std::vector<int> nPerRankBytes;
     std::vector<int> displacements;
@@ -254,7 +254,7 @@ inline std::vector<T> gatherObjects(const std::vector<T> &objects, int root, con
 
     /// (3) gather results
     MPI_Gatherv((void *) objects.data(), static_cast<int>(objects.size() * sizeof(T)), MPI_BYTE, results.data(),
-                nPerRankBytes.data(), displacements.data(), MPI_BYTE, 0, comm);
+                nPerRankBytes.data(), displacements.data(), MPI_BYTE, root, comm);
     return results;
 }
 

--- a/kernels/mpi/include/readdy/kernel/mpi/model/MPIUtils.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/model/MPIUtils.h
@@ -210,4 +210,52 @@ inline void evaluateOnContainers(ParticleContainer &&particleContainer,
     }
 }
 
+/**
+ * Wrapper around two calls Gather and Gatherv,
+ * to find out how many objects each one sends (1),
+ * then set the appropriate displacements (2),
+ * and then gather all variable length data (3).
+ *
+ * @tparam T, the type of sent objects
+ * @param objects, the vector of sent objects
+ * @param root, the rank of the worker which will end up with the union of all sent objects
+ * @param domain, domain object with rank information of current worker
+ * @param comm, communicator for the set of workers
+ * @return the union of all sent objects if on root worker, else an empty vector
+ */
+template<typename T>
+inline std::vector<T> gatherObjects(const std::vector<T> &objects, int root, const model::MPIDomain &domain, const MPI_Comm &comm) {
+    /// (1) find out how many each one sends. In principle the root can also send objects.
+    int number = objects.size();
+    std::vector<int> nPerRank(domain.nUsedRanks(), 0);
+    MPI_Gather(&number, 1, MPI_INT, nPerRank.data(), 1, MPI_INT, 0, comm);
+
+    std::vector<int> nPerRankBytes;
+    std::vector<int> displacements;
+    std::vector<T> results;
+
+    if (domain.rank() == root) {
+        /// (2) find out number of bytes and displacements
+        nPerRankBytes.resize(domain.nUsedRanks());
+        // convert number of objects to number of bytes from each rank
+        for (std::size_t i = 0; i<nPerRank.size(); ++i) {
+            nPerRankBytes[i] = static_cast<int>(nPerRank[i] * sizeof(T));
+        }
+
+        // prepare receive buffer and displacements
+        std::size_t totalNumber = std::accumulate(nPerRank.begin(), nPerRank.end(), 0);
+        results.resize(totalNumber);
+        displacements.resize(domain.nUsedRanks());
+        displacements[0] = 0;
+        for (int i = 1; i<displacements.size(); ++i) {
+            displacements[i] = displacements[i-1] + nPerRankBytes[i-1];
+        }
+    }
+
+    /// (3) gather results
+    MPI_Gatherv((void *) objects.data(), static_cast<int>(objects.size() * sizeof(T)), MPI_BYTE, results.data(),
+                nPerRankBytes.data(), displacements.data(), MPI_BYTE, 0, comm);
+    return results;
+}
+
 }

--- a/kernels/mpi/include/readdy/kernel/mpi/observables/MPIObservableFactory.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/observables/MPIObservableFactory.h
@@ -33,10 +33,8 @@
  ********************************************************************/
 
 /**
- * « detailed description »
- *
  * @file MPIObservableFactory.h
- * @brief « brief description »
+ * @brief Declaration of observable factory for the MPI kernel
  * @author chrisfroe
  * @date 03.06.19
  */
@@ -54,32 +52,38 @@ class MPIObservableFactory : public readdy::model::observables::ObservableFactor
 public:
     explicit MPIObservableFactory(MPIKernel* kernel);
 
-    std::unique_ptr<readdy::model::observables::Energy> energy(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Energy>
+    energy(Stride stride, ObsCallBack<readdy::model::observables::Energy> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Virial> virial(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Virial>
+    virial(Stride stride, ObsCallBack<readdy::model::observables::Virial> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
     histogramAlongAxis(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typesToCount,
-                       unsigned int axis) const override;
+                       unsigned int axis, ObsCallBack<readdy::model::observables::HistogramAlongAxis> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::NParticles>
-    nParticles(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::NParticles>
+    nParticles(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<readdy::model::observables::NParticles> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Forces>
-    forces(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Forces>
+    forces(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<readdy::model::observables::Forces> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Positions>
-    positions(Stride stride, std::vector<std::string> typesToCount) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Positions>
+    positions(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<readdy::model::observables::Positions> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::RadialDistribution>
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::RadialDistribution>
     radialDistribution(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typeCountFrom,
-                       std::vector<std::string> typeCountTo, scalar particleDensity) const override;
+                       std::vector<std::string> typeCountTo, scalar particleDensity,
+                       ObsCallBack <readdy::model::observables::RadialDistribution> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Particles> particles(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Particles>
+    particles(Stride stride, ObsCallBack<readdy::model::observables::Particles> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::Reactions> reactions(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::Reactions>
+    reactions(Stride stride, ObsCallBack<readdy::model::observables::Reactions> callback) const override;
 
-    std::unique_ptr<readdy::model::observables::ReactionCounts> reactionCounts(Stride stride) const override;
+    [[nodiscard]] std::unique_ptr<readdy::model::observables::ReactionCounts>
+    reactionCounts(Stride stride, ObsCallBack<readdy::model::observables::ReactionCounts> callback) const override;
 
 private:
     MPIKernel *const kernel;

--- a/kernels/mpi/include/readdy/kernel/mpi/observables/MPIObservableFactory.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/observables/MPIObservableFactory.h
@@ -53,37 +53,37 @@ public:
     explicit MPIObservableFactory(MPIKernel* kernel);
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Energy>
-    energy(Stride stride, ObsCallBack<readdy::model::observables::Energy> callback) const override;
+    energy(Stride stride, ObsCallback<readdy::model::observables::Energy> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Virial>
-    virial(Stride stride, ObsCallBack<readdy::model::observables::Virial> callback) const override;
+    virial(Stride stride, ObsCallback<readdy::model::observables::Virial> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
     histogramAlongAxis(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typesToCount,
-                       unsigned int axis, ObsCallBack<readdy::model::observables::HistogramAlongAxis> callback) const override;
+                       unsigned int axis, ObsCallback<readdy::model::observables::HistogramAlongAxis> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::NParticles>
-    nParticles(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<readdy::model::observables::NParticles> callback) const override;
+    nParticles(Stride stride, std::vector<std::string> typesToCount, ObsCallback<readdy::model::observables::NParticles> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Forces>
-    forces(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<readdy::model::observables::Forces> callback) const override;
+    forces(Stride stride, std::vector<std::string> typesToCount, ObsCallback<readdy::model::observables::Forces> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Positions>
-    positions(Stride stride, std::vector<std::string> typesToCount, ObsCallBack<readdy::model::observables::Positions> callback) const override;
+    positions(Stride stride, std::vector<std::string> typesToCount, ObsCallback<readdy::model::observables::Positions> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::RadialDistribution>
     radialDistribution(Stride stride, std::vector<scalar> binBorders, std::vector<std::string> typeCountFrom,
                        std::vector<std::string> typeCountTo, scalar particleDensity,
-                       ObsCallBack <readdy::model::observables::RadialDistribution> callback) const override;
+                       ObsCallback <readdy::model::observables::RadialDistribution> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Particles>
-    particles(Stride stride, ObsCallBack<readdy::model::observables::Particles> callback) const override;
+    particles(Stride stride, ObsCallback<readdy::model::observables::Particles> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::Reactions>
-    reactions(Stride stride, ObsCallBack<readdy::model::observables::Reactions> callback) const override;
+    reactions(Stride stride, ObsCallback<readdy::model::observables::Reactions> callback) const override;
 
     [[nodiscard]] std::unique_ptr<readdy::model::observables::ReactionCounts>
-    reactionCounts(Stride stride, ObsCallBack<readdy::model::observables::ReactionCounts> callback) const override;
+    reactionCounts(Stride stride, ObsCallback<readdy::model::observables::ReactionCounts> callback) const override;
 
 private:
     MPIKernel *const kernel;

--- a/kernels/mpi/include/readdy/kernel/mpi/observables/MPIObservables.h
+++ b/kernels/mpi/include/readdy/kernel/mpi/observables/MPIObservables.h
@@ -82,10 +82,9 @@ public:
 protected:
     MPIKernel *kernel;
 
-    // todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 class MPIPositions : public readdy::model::observables::Positions {
@@ -97,25 +96,24 @@ public:
 protected:
     MPIKernel *kernel;
 
-    // todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 class MPIParticles : public readdy::model::observables::Particles {
 public:
     MPIParticles(MPIKernel *kernel, unsigned int stride);
 
+    // fixme note that returned particle ids are meaningless, they do not reflect the ids present on the workers' states
     void evaluate() override;
 
 protected:
     MPIKernel *kernel;
 
-    // todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 class MPIHistogramAlongAxis : public readdy::model::observables::HistogramAlongAxis {
@@ -131,10 +129,9 @@ public:
 protected:
     MPIKernel *kernel;
 
-    //todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 class MPINParticles : public readdy::model::observables::NParticles {
@@ -148,10 +145,9 @@ public:
 protected:
     MPIKernel *kernel;
 
-    //todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 class MPIForces : public readdy::model::observables::Forces {
@@ -166,10 +162,9 @@ public:
 protected:
     MPIKernel *kernel;
 
-    // todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 class MPIReactions : public readdy::model::observables::Reactions {
@@ -181,10 +176,9 @@ public:
 protected:
     MPIKernel *kernel;
 
-    // todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 class MPIReactionCounts : public readdy::model::observables::ReactionCounts {
@@ -196,10 +190,9 @@ public:
 protected:
     MPIKernel *kernel;
 
-    // todo
-    //void append() override;
+    void append() override;
 
-    //void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
+    void initializeDataSet(File &file, const std::string &dataSetName, Stride flushStride) override;
 };
 
 }

--- a/kernels/mpi/src/MPIKernel.cpp
+++ b/kernels/mpi/src/MPIKernel.cpp
@@ -46,12 +46,6 @@
 
 namespace readdy::kernel::mpi {
 
-const std::string MPIKernel::name = "MPI";
-
-readdy::model::Kernel *MPIKernel::create() {
-    return new MPIKernel();
-}
-
 MPIKernel::MPIKernel() : MPIKernel(readdy::model::Context{}) {}
 
 // pay attention to order of initialization, which is defined by class hierarchy, then by order of declaration
@@ -94,6 +88,16 @@ MPIKernel::MPIKernel(const readdy::model::Context &ctx)
     _stateModel.reactionRecords().clear();
     _stateModel.resetReactionCounts();
     _stateModel.virial() = Matrix33{{{0, 0, 0, 0, 0, 0, 0, 0, 0}}};
+}
+
+const std::string MPIKernel::name = "MPI";
+
+readdy::model::Kernel *MPIKernel::create(const readdy::model::Context &ctx) {
+    return new MPIKernel(ctx);
+}
+
+readdy::model::Kernel *MPIKernel::create() {
+    return new MPIKernel();
 }
 
 }

--- a/kernels/mpi/src/MPISession.cpp
+++ b/kernels/mpi/src/MPISession.cpp
@@ -39,8 +39,8 @@ void MPISession::waitForDebugger() {
         MPI_Get_processor_name(processorName, &nameLen);
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-        static int rankToDebug = 2;
-        if (rank == rankToDebug) {
+        static int rankToDebug = 0;
+        if (rank == rankToDebug or rank == 1) {
             volatile int i = 0;
             readdy::log::warn("pid {} w/ rank {} on processor {} waiting for debugger",
                               static_cast<unsigned long>(getpid()), rank, processorName);

--- a/kernels/mpi/src/MPIStateModel.cpp
+++ b/kernels/mpi/src/MPIStateModel.cpp
@@ -76,7 +76,7 @@ MPIStateModel::gatherParticles() const {
             }
         }
     }
-    thinParticles = util::gatherObjects(thinParticles, _domain->rank(), *_domain, commUsedRanks());
+    thinParticles = util::gatherObjects(thinParticles, 0, *_domain, commUsedRanks());
 
     // convert to particles
     std::vector<Particle> particles;

--- a/kernels/mpi/src/MPIStateModel.cpp
+++ b/kernels/mpi/src/MPIStateModel.cpp
@@ -66,51 +66,25 @@ MPIStateModel::gatherParticles() const {
         return {};
     }
     readdy::util::Timer timer("MPIStateModel::gatherParticles");
-    auto &data = _data.get();
 
-    // find out how many particles (and bytes) each worker sends
-    int nParticles = 0;
+    std::vector<util::ParticlePOD> thinParticles;
     if (_domain->isWorkerRank()) {
-        nParticles = std::count_if(data.begin(), data.end(), [](const MPIEntry &entry) {return not entry.deactivated and entry.responsible;});
-    }
-    std::vector<int> numberParticles(_domain->nUsedRanks(), 0);
-
-    MPI_Gather(&nParticles, 1, MPI_INT, numberParticles.data(), 1, MPI_INT, 0, _commUsedRanks);
-
-    std::vector<int> numberBytes(_domain->nUsedRanks(), 0);
-    // convert number of particles to number of bytes from each rank
-    for (std::size_t i = 0; i<numberParticles.size(); ++i) {
-        numberBytes[i] = static_cast<int>(numberParticles[i] * sizeof(util::ParticlePOD));
-    }
-
-    // now send and receive thin particles
-    if (_domain->isMasterRank()) {
-        std::size_t totalNumberParticles = std::accumulate(numberParticles.begin(), numberParticles.end(), 0);
-        std::vector<util::ParticlePOD> thinParticles(totalNumberParticles, {{0., 0., 0.}, 0}); // receive buffer
-        std::vector<int> displacements(_domain->nUsedRanks(), 0);
-        displacements[0] = 0;
-        for (int i = 1; i<displacements.size(); ++i) {
-            displacements[i] = displacements[i-1] + numberBytes[i-1];
-        }
-        MPI_Gatherv(nullptr, 0, MPI_BYTE, thinParticles.data(), numberBytes.data(), displacements.data(), MPI_BYTE, 0, _commUsedRanks);
-        // convert to particles
-        std::vector<Particle> particles;
-        std::for_each(thinParticles.begin(), thinParticles.end(),
-                      [&particles](const util::ParticlePOD &tp) {
-                          particles.emplace_back(tp.position, tp.typeId);
-                      });
-        return particles;
-    } else {
         // prepare send data
-        std::vector<util::ParticlePOD> thinParticles;
         for (const MPIEntry &entry : _data.get()) {
             if (not entry.deactivated and entry.responsible) {
                 thinParticles.emplace_back(entry);
             }
         }
-        MPI_Gatherv((void *) thinParticles.data(), static_cast<int>(thinParticles.size() * sizeof(util::ParticlePOD)), MPI_BYTE, nullptr, nullptr, nullptr, nullptr, 0, _commUsedRanks);
-        return {};
     }
+    thinParticles = util::gatherObjects(thinParticles, _domain->rank(), *_domain, commUsedRanks());
+
+    // convert to particles
+    std::vector<Particle> particles;
+    std::for_each(thinParticles.begin(), thinParticles.end(),
+                  [&particles](const util::ParticlePOD &tp) {
+                      particles.emplace_back(tp.position, tp.typeId);
+                  });
+    return particles;
 }
 
 void MPIStateModel::resetReactionCounts() {

--- a/kernels/mpi/src/actions/MPIActionFactory.cpp
+++ b/kernels/mpi/src/actions/MPIActionFactory.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<readdy::model::actions::MdgfrdIntegrator> MPIActionFactory::mdgf
 
 std::unique_ptr<readdy::model::actions::CreateNeighborList>
 MPIActionFactory::createNeighborList(scalar interactionDistance) const {
-    return {nullptr};
+    return {std::make_unique<MPICreateNeighborList>(kernel)};
 }
 
 std::unique_ptr<readdy::model::actions::UpdateNeighborList> MPIActionFactory::updateNeighborList() const {
@@ -75,7 +75,7 @@ std::unique_ptr<readdy::model::actions::UpdateNeighborList> MPIActionFactory::up
 }
 
 std::unique_ptr<readdy::model::actions::ClearNeighborList> MPIActionFactory::clearNeighborList() const {
-    return {nullptr};
+    return {std::make_unique<MPIClearNeighborList>()};
 }
 
 std::unique_ptr<readdy::model::actions::EvaluateCompartments> MPIActionFactory::evaluateCompartments() const {

--- a/kernels/mpi/src/actions/MPIActionFactory.cpp
+++ b/kernels/mpi/src/actions/MPIActionFactory.cpp
@@ -113,8 +113,8 @@ std::unique_ptr<readdy::model::actions::EvaluateObservables> MPIActionFactory::e
 }
 
 std::unique_ptr<readdy::model::actions::MakeCheckpoint>
-MPIActionFactory::makeCheckpoint(std::string base, std::size_t maxNSaves) const {
-    return {std::make_unique<MPIMakeCheckpoint>(kernel, base, maxNSaves)};
+MPIActionFactory::makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const {
+    return {std::make_unique<MPIMakeCheckpoint>(kernel, base, maxNSaves, checkpointFormat)};
 }
 
 std::unique_ptr<readdy::model::actions::InitializeKernel> MPIActionFactory::initializeKernel() const {

--- a/kernels/mpi/src/observables/MPIObservableFactory.cpp
+++ b/kernels/mpi/src/observables/MPIObservableFactory.cpp
@@ -51,7 +51,7 @@ MPIObservableFactory::MPIObservableFactory(MPIKernel *kernel) : readdy::model::o
 std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
 MPIObservableFactory::histogramAlongAxis(Stride stride, std::vector<scalar> binBorders,
                                          std::vector<std::string> typesToCount, unsigned int axis,
-                                         ObsCallBack<readdy::model::observables::HistogramAlongAxis> callback) const {
+                                         ObsCallback<readdy::model::observables::HistogramAlongAxis> callback) const {
     auto obs = std::make_unique<MPIHistogramAlongAxis>(kernel, stride, binBorders, typesToCount, axis);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -61,7 +61,7 @@ MPIObservableFactory::histogramAlongAxis(Stride stride, std::vector<scalar> binB
 
 std::unique_ptr<readdy::model::observables::NParticles>
 MPIObservableFactory::nParticles(Stride stride, std::vector<std::string> typesToCount,
-                                 ObsCallBack<readdy::model::observables::NParticles> callback) const {
+                                 ObsCallback<readdy::model::observables::NParticles> callback) const {
     auto obs = std::make_unique<MPINParticles>(kernel, stride, typesToCount);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -71,7 +71,7 @@ MPIObservableFactory::nParticles(Stride stride, std::vector<std::string> typesTo
 
 std::unique_ptr<readdy::model::observables::Forces>
 MPIObservableFactory::forces(Stride stride, std::vector<std::string> typesToCount,
-                             ObsCallBack<readdy::model::observables::Forces> callback) const {
+                             ObsCallback<readdy::model::observables::Forces> callback) const {
     auto obs = std::make_unique<MPIForces>(kernel, stride, typesToCount);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -81,7 +81,7 @@ MPIObservableFactory::forces(Stride stride, std::vector<std::string> typesToCoun
 
 std::unique_ptr<readdy::model::observables::Positions>
 MPIObservableFactory::positions(Stride stride, std::vector<std::string> typesToCount,
-                                ObsCallBack<readdy::model::observables::Positions> callback) const {
+                                ObsCallback<readdy::model::observables::Positions> callback) const {
     auto obs = std::make_unique<MPIPositions>(kernel, stride, typesToCount);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -93,7 +93,7 @@ std::unique_ptr<readdy::model::observables::RadialDistribution>
 MPIObservableFactory::radialDistribution(Stride stride, std::vector<scalar> binBorders,
                                          std::vector<std::string> typeCountFrom,
                                          std::vector<std::string> typeCountTo, scalar particleDensity,
-                                         ObsCallBack<readdy::model::observables::RadialDistribution> callback) const {
+                                         ObsCallback<readdy::model::observables::RadialDistribution> callback) const {
     auto obs = std::make_unique<readdy::model::observables::RadialDistribution>(
             kernel, stride, binBorders, typeCountFrom, typeCountTo, particleDensity
     );
@@ -104,7 +104,7 @@ MPIObservableFactory::radialDistribution(Stride stride, std::vector<scalar> binB
 }
 
 std::unique_ptr<readdy::model::observables::Particles>
-MPIObservableFactory::particles(Stride stride, ObsCallBack<readdy::model::observables::Particles> callback) const {
+MPIObservableFactory::particles(Stride stride, ObsCallback<readdy::model::observables::Particles> callback) const {
     auto obs = std::make_unique<MPIParticles>(kernel, stride);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -113,7 +113,7 @@ MPIObservableFactory::particles(Stride stride, ObsCallBack<readdy::model::observ
 }
 
 std::unique_ptr<readdy::model::observables::Reactions>
-MPIObservableFactory::reactions(Stride stride, ObsCallBack<readdy::model::observables::Reactions> callback) const {
+MPIObservableFactory::reactions(Stride stride, ObsCallback<readdy::model::observables::Reactions> callback) const {
     auto obs = std::make_unique<MPIReactions>(kernel, stride);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -123,7 +123,7 @@ MPIObservableFactory::reactions(Stride stride, ObsCallBack<readdy::model::observ
 }
 
 std::unique_ptr<readdy::model::observables::ReactionCounts>
-MPIObservableFactory::reactionCounts(Stride stride, ObsCallBack<readdy::model::observables::ReactionCounts> callback) const {
+MPIObservableFactory::reactionCounts(Stride stride, ObsCallback<readdy::model::observables::ReactionCounts> callback) const {
     auto obs = std::make_unique<MPIReactionCounts>(kernel, stride);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -132,7 +132,7 @@ MPIObservableFactory::reactionCounts(Stride stride, ObsCallBack<readdy::model::o
     return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::Virial> MPIObservableFactory::virial(Stride stride, ObsCallBack<readdy::model::observables::Virial> callback) const {
+std::unique_ptr<readdy::model::observables::Virial> MPIObservableFactory::virial(Stride stride, ObsCallback<readdy::model::observables::Virial> callback) const {
     auto obs = std::make_unique<MPIVirial>(kernel, stride);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);
@@ -141,7 +141,7 @@ std::unique_ptr<readdy::model::observables::Virial> MPIObservableFactory::virial
     return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::Energy> MPIObservableFactory::energy(Stride stride, ObsCallBack<readdy::model::observables::Energy> callback) const {
+std::unique_ptr<readdy::model::observables::Energy> MPIObservableFactory::energy(Stride stride, ObsCallback<readdy::model::observables::Energy> callback) const {
     auto obs = std::make_unique<MPIEnergy>(kernel, stride);
     if (kernel->domain().isMasterRank()) {
         obs->setCallback(callback);

--- a/kernels/mpi/src/observables/MPIObservableFactory.cpp
+++ b/kernels/mpi/src/observables/MPIObservableFactory.cpp
@@ -33,10 +33,8 @@
  ********************************************************************/
 
 /**
- * « detailed description »
- *
  * @file MPIObservableFactory.cpp
- * @brief « brief description »
+ * @brief Implementation of the observable factor for the MPI kernel
  * @author chrisfroe
  * @date 28.05.19
  */
@@ -52,52 +50,103 @@ MPIObservableFactory::MPIObservableFactory(MPIKernel *kernel) : readdy::model::o
 
 std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
 MPIObservableFactory::histogramAlongAxis(Stride stride, std::vector<scalar> binBorders,
-                                         std::vector<std::string> typesToCount, unsigned int axis) const {
-    return {std::make_unique<MPIHistogramAlongAxis>(kernel, stride, binBorders, typesToCount, axis)};
+                                         std::vector<std::string> typesToCount, unsigned int axis,
+                                         ObsCallBack<readdy::model::observables::HistogramAlongAxis> callback) const {
+    auto obs = std::make_unique<MPIHistogramAlongAxis>(kernel, stride, binBorders, typesToCount, axis);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    return std::move(obs);
 }
 
 std::unique_ptr<readdy::model::observables::NParticles>
-MPIObservableFactory::nParticles(Stride stride, std::vector<std::string> typesToCount) const {
-    return {std::make_unique<MPINParticles>(kernel, stride, typesToCount)};
+MPIObservableFactory::nParticles(Stride stride, std::vector<std::string> typesToCount,
+                                 ObsCallBack<readdy::model::observables::NParticles> callback) const {
+    auto obs = std::make_unique<MPINParticles>(kernel, stride, typesToCount);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    return std::move(obs);
 }
 
 std::unique_ptr<readdy::model::observables::Forces>
-MPIObservableFactory::forces(Stride stride, std::vector<std::string> typesToCount) const {
-    return {std::make_unique<MPIForces>(kernel, stride, typesToCount)};
+MPIObservableFactory::forces(Stride stride, std::vector<std::string> typesToCount,
+                             ObsCallBack<readdy::model::observables::Forces> callback) const {
+    auto obs = std::make_unique<MPIForces>(kernel, stride, typesToCount);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    return std::move(obs);
 }
 
 std::unique_ptr<readdy::model::observables::Positions>
-MPIObservableFactory::positions(Stride stride, std::vector<std::string> typesToCount) const {
-    return {std::make_unique<MPIPositions>(kernel, stride, typesToCount)};
+MPIObservableFactory::positions(Stride stride, std::vector<std::string> typesToCount,
+                                ObsCallBack<readdy::model::observables::Positions> callback) const {
+    auto obs = std::make_unique<MPIPositions>(kernel, stride, typesToCount);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    return std::move(obs);
 }
 
 std::unique_ptr<readdy::model::observables::RadialDistribution>
 MPIObservableFactory::radialDistribution(Stride stride, std::vector<scalar> binBorders,
-                                         std::vector<std::string> typeCountFrom, std::vector<std::string> typeCountTo,
-                                         scalar particleDensity) const {
-    return {std::make_unique<readdy::model::observables::RadialDistribution>(
+                                         std::vector<std::string> typeCountFrom,
+                                         std::vector<std::string> typeCountTo, scalar particleDensity,
+                                         ObsCallBack<readdy::model::observables::RadialDistribution> callback) const {
+    auto obs = std::make_unique<readdy::model::observables::RadialDistribution>(
             kernel, stride, binBorders, typeCountFrom, typeCountTo, particleDensity
-    )};
+    );
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::Particles> MPIObservableFactory::particles(Stride stride) const {
-    return {std::make_unique<MPIParticles>(kernel, stride)};
+std::unique_ptr<readdy::model::observables::Particles>
+MPIObservableFactory::particles(Stride stride, ObsCallBack<readdy::model::observables::Particles> callback) const {
+    auto obs = std::make_unique<MPIParticles>(kernel, stride);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::Reactions> MPIObservableFactory::reactions(Stride stride) const {
-    return {std::make_unique<MPIReactions>(kernel, stride)};
+std::unique_ptr<readdy::model::observables::Reactions>
+MPIObservableFactory::reactions(Stride stride, ObsCallBack<readdy::model::observables::Reactions> callback) const {
+    auto obs = std::make_unique<MPIReactions>(kernel, stride);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    kernel->context().recordReactionsWithPositions() = true;
+    return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::ReactionCounts> MPIObservableFactory::reactionCounts(Stride stride) const {
-    return {std::make_unique<MPIReactionCounts>(kernel, stride)};
+std::unique_ptr<readdy::model::observables::ReactionCounts>
+MPIObservableFactory::reactionCounts(Stride stride, ObsCallBack<readdy::model::observables::ReactionCounts> callback) const {
+    auto obs = std::make_unique<MPIReactionCounts>(kernel, stride);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    kernel->context().recordReactionCounts() = true;
+    return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::Virial> MPIObservableFactory::virial(Stride stride) const {
-    return {std::make_unique<MPIVirial>(kernel, stride)};
+std::unique_ptr<readdy::model::observables::Virial> MPIObservableFactory::virial(Stride stride, ObsCallBack<readdy::model::observables::Virial> callback) const {
+    auto obs = std::make_unique<MPIVirial>(kernel, stride);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    kernel->context().recordVirial() = true;
+    return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::Energy> MPIObservableFactory::energy(Stride stride) const {
-    return {std::make_unique<MPIEnergy>(kernel, stride)};
+std::unique_ptr<readdy::model::observables::Energy> MPIObservableFactory::energy(Stride stride, ObsCallBack<readdy::model::observables::Energy> callback) const {
+    auto obs = std::make_unique<MPIEnergy>(kernel, stride);
+    if (kernel->domain().isMasterRank()) {
+        obs->setCallback(callback);
+    }
+    return std::move(obs);
 }
 
 }

--- a/kernels/mpi/test/regular/CMakeLists.txt
+++ b/kernels/mpi/test/regular/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(${PROJECT_NAME}
         IntegrationTests.cpp
         TestSynchronization.cpp
         TestDiffusion.cpp
+        TestObservables.cpp
         ${TESTING_INCLUDE_DIR})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${READDY_INCLUDE_DIRS} ${TESTING_INCLUDE_DIR} ${MPI_INCLUDE_DIR})

--- a/kernels/mpi/test/regular/TestObservables.cpp
+++ b/kernels/mpi/test/regular/TestObservables.cpp
@@ -1,0 +1,86 @@
+/********************************************************************
+ * Copyright © 2020 Computational Molecular Biology Group,          *
+ *                  Freie Universität Berlin (GER)                  *
+ *                                                                  *
+ * Redistribution and use in source and binary forms, with or       *
+ * without modification, are permitted provided that the            *
+ * following conditions are met:                                    *
+ *  1. Redistributions of source code must retain the above         *
+ *     copyright notice, this list of conditions and the            *
+ *     following disclaimer.                                        *
+ *  2. Redistributions in binary form must reproduce the above      *
+ *     copyright notice, this list of conditions and the following  *
+ *     disclaimer in the documentation and/or other materials       *
+ *     provided with the distribution.                              *
+ *  3. Neither the name of the copyright holder nor the names of    *
+ *     its contributors may be used to endorse or promote products  *
+ *     derived from this software without specific                  *
+ *     prior written permission.                                    *
+ *                                                                  *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND           *
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,      *
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF         *
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE         *
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR            *
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,     *
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,         *
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER *
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,      *
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)    *
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF      *
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ ********************************************************************/
+
+
+/**
+ * << detailed description >>
+ *
+ * @file TestObservables.cpp
+ * @brief << brief description >>
+ * @author chrisfroe
+ * @date 22.04.20
+ */
+
+#include <catch2/catch.hpp>
+#include <readdy/kernel/mpi/MPIKernel.h>
+#include <readdy/api/Simulation.h>
+
+using Json = nlohmann::json;
+
+TEST_CASE("Test particles observable", "[mpi]") {
+    readdy::model::Context ctx;
+
+    /// In and out types and positions
+    ctx.boxSize() = {10., 10., 10.};
+    ctx.particleTypes().add("A", 1.);
+    ctx.particleTypes().add("B", 1.);
+    //ctx.reactions().add("fusili: A +(1.) A -> B", 0.1);
+    ctx.potentials().addHarmonicRepulsion("A", "A", 10., 2.3);
+    Json conf = {{"MPI", {{"dx", 4.9}, {"dy", 4.9}, {"dz", 4.9}}}};
+    ctx.kernelConfiguration() = conf.get<readdy::conf::Configuration>();
+
+    // ugly hack to use the simulation interface with the MPI Kernel
+    readdy::plugin::KernelProvider::kernel_ptr kernelPtr = std::unique_ptr<readdy::model::Kernel, readdy::plugin::KernelDeleter>(
+            readdy::kernel::mpi::MPIKernel::create(ctx));
+    readdy::Simulation simulation(std::move(kernelPtr), ctx);
+
+    REQUIRE(simulation.selectedKernelType() == "MPI");
+
+    const std::size_t nParticles = 10000;
+    for (std::size_t i = 0; i < nParticles; ++i) {
+        auto x = readdy::model::rnd::uniform_real() * 10. - 5.;
+        auto y = readdy::model::rnd::uniform_real() * 10. - 5.;
+        auto z = readdy::model::rnd::uniform_real() * 10. - 5.;
+        simulation.addParticle("A", x, y, z);
+    }
+    const auto idA = ctx.particleTypes().idOf("A");
+    auto check = [&nParticles, &idA](readdy::model::observables::Particles::result_type result) {
+        const auto &types = std::get<0>(result);
+        const auto &ids = std::get<1>(result);
+        const auto &positions = std::get<2>(result);
+        CHECK(std::count(types.begin(), types.end(), idA) == 10000);
+    };
+    auto obsHandle = simulation.registerObservable(simulation.observe().particles(1), check);
+    simulation.run(100, 0.01);
+}

--- a/kernels/singlecpu/src/SCPUActionFactory.cpp
+++ b/kernels/singlecpu/src/SCPUActionFactory.cpp
@@ -130,8 +130,8 @@ std::unique_ptr<readdy::model::actions::EvaluateObservables> SCPUActionFactory::
     return {std::make_unique<SCPUEvaluateObservables>(kernel)};
 }
 
-std::unique_ptr<readdy::model::actions::MakeCheckpoint> SCPUActionFactory::makeCheckpoint(std::string base, std::size_t maxNSaves) const {
-    return {std::make_unique<SCPUMakeCheckpoint>(kernel, base, maxNSaves)};
+std::unique_ptr<readdy::model::actions::MakeCheckpoint> SCPUActionFactory::makeCheckpoint(std::string base, std::size_t maxNSaves, std::string checkpointFormat) const {
+    return {std::make_unique<SCPUMakeCheckpoint>(kernel, base, maxNSaves, checkpointFormat)};
 }
 
 std::unique_ptr<readdy::model::actions::InitializeKernel> SCPUActionFactory::initializeKernel() const {

--- a/kernels/singlecpu/src/observables/SCPUObservableFactory.cpp
+++ b/kernels/singlecpu/src/observables/SCPUObservableFactory.cpp
@@ -52,15 +52,15 @@ SCPUObservableFactory::SCPUObservableFactory(readdy::kernel::scpu::SCPUKernel *c
 std::unique_ptr<readdy::model::observables::HistogramAlongAxis>
 SCPUObservableFactory::histogramAlongAxis(Stride stride, std::vector<scalar> binBorders,
                                           std::vector<std::string> typesToCount, unsigned int axis,
-                                          ObsCallBack <readdy::model::observables::HistogramAlongAxis> callBack) const {
+                                          ObsCallback <readdy::model::observables::HistogramAlongAxis> callback) const {
     auto obs = std::make_unique<SCPUHistogramAlongAxis>(kernel, stride, binBorders, typesToCount, axis);
-    obs->setCallback(callBack);
+    obs->setCallback(callback);
     return std::move(obs);
 }
 
 std::unique_ptr<readdy::model::observables::NParticles>
 SCPUObservableFactory::nParticles(Stride stride, std::vector<std::string> typesToCount,
-                                  ObsCallBack <readdy::model::observables::NParticles> callback) const {
+                                  ObsCallback <readdy::model::observables::NParticles> callback) const {
     auto obs = std::make_unique<SCPUNParticles>(kernel, stride, typesToCount);
     obs->setCallback(callback);
     return std::move(obs);
@@ -68,7 +68,7 @@ SCPUObservableFactory::nParticles(Stride stride, std::vector<std::string> typesT
 
 std::unique_ptr<readdy::model::observables::Forces>
 SCPUObservableFactory::forces(Stride stride, std::vector<std::string> typesToCount,
-                              ObsCallBack<readdy::model::observables::Forces> callback) const {
+                              ObsCallback<readdy::model::observables::Forces> callback) const {
     auto obs = std::make_unique<SCPUForces>(kernel, stride, typesToCount);
     obs->setCallback(callback);
     return std::move(obs);
@@ -76,7 +76,7 @@ SCPUObservableFactory::forces(Stride stride, std::vector<std::string> typesToCou
 
 std::unique_ptr<readdy::model::observables::Positions>
 SCPUObservableFactory::positions(Stride stride, std::vector<std::string> typesToCount,
-                                 ObsCallBack<readdy::model::observables::Positions> callback) const {
+                                 ObsCallback<readdy::model::observables::Positions> callback) const {
     auto obs = std::make_unique<SCPUPositions>(kernel, stride, typesToCount);
     obs->setCallback(callback);
     return std::move(obs);
@@ -86,7 +86,7 @@ std::unique_ptr<readdy::model::observables::RadialDistribution>
 SCPUObservableFactory::radialDistribution(Stride stride, std::vector<scalar> binBorders,
                                           std::vector<std::string> typeCountFrom,
                                           std::vector<std::string> typeCountTo, scalar particleDensity,
-                                          ObsCallBack<readdy::model::observables::RadialDistribution> callback) const {
+                                          ObsCallback<readdy::model::observables::RadialDistribution> callback) const {
     auto obs = std::make_unique<readdy::model::observables::RadialDistribution>(
             kernel, stride, binBorders, typeCountFrom, typeCountTo, particleDensity);
     obs->setCallback(callback);
@@ -94,14 +94,14 @@ SCPUObservableFactory::radialDistribution(Stride stride, std::vector<scalar> bin
 }
 
 std::unique_ptr<readdy::model::observables::Particles>
-SCPUObservableFactory::particles(Stride stride, ObsCallBack<readdy::model::observables::Particles> callback) const {
+SCPUObservableFactory::particles(Stride stride, ObsCallback<readdy::model::observables::Particles> callback) const {
     auto obs = std::make_unique<SCPUParticles>(kernel, stride);
     obs->setCallback(callback);
     return std::move(obs);
 }
 
 std::unique_ptr<readdy::model::observables::Reactions>
-SCPUObservableFactory::reactions(Stride stride, ObsCallBack<readdy::model::observables::Reactions> callback) const {
+SCPUObservableFactory::reactions(Stride stride, ObsCallback<readdy::model::observables::Reactions> callback) const {
     auto obs = std::make_unique<SCPUReactions>(kernel, stride);
     obs->setCallback(callback);
     kernel->context().recordReactionsWithPositions() = true;
@@ -109,7 +109,7 @@ SCPUObservableFactory::reactions(Stride stride, ObsCallBack<readdy::model::obser
 }
 
 std::unique_ptr<readdy::model::observables::ReactionCounts>
-SCPUObservableFactory::reactionCounts(Stride stride, ObsCallBack<readdy::model::observables::ReactionCounts> callback) const {
+SCPUObservableFactory::reactionCounts(Stride stride, ObsCallback<readdy::model::observables::ReactionCounts> callback) const {
     auto obs = std::make_unique<SCPUReactionCounts>(kernel, stride);
     obs->setCallback(callback);
     kernel->context().recordReactionCounts() = true;
@@ -117,16 +117,16 @@ SCPUObservableFactory::reactionCounts(Stride stride, ObsCallBack<readdy::model::
 }
 
 std::unique_ptr<readdy::model::observables::Virial>
-SCPUObservableFactory::virial(Stride stride, ObsCallBack<readdy::model::observables::Virial> callBack) const {
+SCPUObservableFactory::virial(Stride stride, ObsCallback<readdy::model::observables::Virial> callback) const {
     std::unique_ptr<readdy::model::observables::Virial> obs = std::make_unique<SCPUVirial>(kernel, stride);
-    obs->setCallback(callBack);
+    obs->setCallback(callback);
     kernel->context().recordVirial() = true;
     return std::move(obs);
 }
 
-std::unique_ptr<readdy::model::observables::Energy> SCPUObservableFactory::energy(Stride stride, ObsCallBack<readdy::model::observables::Energy> callBack) const {
+std::unique_ptr<readdy::model::observables::Energy> SCPUObservableFactory::energy(Stride stride, ObsCallback<readdy::model::observables::Energy> callback) const {
     auto obs = std::make_unique<readdy::model::observables::Energy>(kernel, stride);
-    obs->setCallback(callBack);
+    obs->setCallback(callback);
     return std::move(obs);
 }
 

--- a/kernels/singlecpu/test/TestReactions.cpp
+++ b/kernels/singlecpu/test/TestReactions.cpp
@@ -59,9 +59,9 @@ TEST_CASE("Test single cpu decay reactions", "[scpu]") {
     auto &&reactions = kernel->actions().uncontrolledApproximation(timeStep);
 
     auto pp_obs = kernel->observe().positions(1);
-    pp_obs->callback() = [](const readdy::model::observables::Positions::result_type &t) {
+    pp_obs->setCallback([](const readdy::model::observables::Positions::result_type &t) {
         readdy::log::trace("got n particles={}", t.size());
-    };
+    });
     auto connection = kernel->connectObservable(pp_obs.get());
 
     const int n_particles = 200;

--- a/readdy/test/IntegrationTests.cpp
+++ b/readdy/test/IntegrationTests.cpp
@@ -77,9 +77,9 @@ TEMPLATE_TEST_CASE("Reaction handlers integration.", "[!hide][integration]", Sin
                 auto &&obs = kernel->observe().nParticles(1, typesToCount);
                 readdy::scalar meanS{0.};
 
-                obs->callback() = [&](const readdy::model::observables::NParticles::result_type &result) {
+                obs->setCallback([&](const readdy::model::observables::NParticles::result_type &result) {
                     meanS += static_cast<readdy::scalar>(result[0]);
-                };
+                });
 
                 auto &&connection = kernel->connectObservable(obs.get());
 
@@ -169,7 +169,7 @@ TEMPLATE_TEST_CASE("Chain-decay integration test", "[!hide][integration]", Singl
 
     auto topsobs = kernel->observe().topologies(1);
     auto connection = kernel->connectObservable(topsobs.get());
-    topsobs->callback() = [&](const readdy::model::observables::Topologies::result_type &result) {
+    topsobs->setCallback([&](const readdy::model::observables::Topologies::result_type &result) {
         auto tops = kernel->stateModel().getTopologies();
         REQUIRE(result.size() == tops.size());
         for (std::size_t i = 0; i < tops.size(); ++i) {
@@ -219,7 +219,7 @@ TEMPLATE_TEST_CASE("Chain-decay integration test", "[!hide][integration]", Singl
             }
 
         }
-    };
+    });
 
     {
         auto integrator = kernel->actions().createIntegrator("EulerBDIntegrator", 1e-2);
@@ -569,14 +569,14 @@ TEMPLATE_TEST_CASE("Helix grows by spatial topology reactions", "[!hide][integra
                 }
             }
 
-            auto obs = simulation.observe().positions(1000, {"B", "C"});
             std::vector<readdy::scalar> distances;
             auto callback = [&distances, &ctx](const std::vector<readdy::Vec3> &dist) {
                 const auto d = readdy::bcs::dist(dist.at(0), dist.at(1), ctx.boxSize(),
                                                  ctx.periodicBoundaryConditions());
                 distances.push_back(d);
             };
-            simulation.registerObservable(std::move(obs), callback);
+            auto obs = simulation.observe().positions(1000, {"B", "C"}, callback);
+            simulation.registerObservable(std::move(obs));
 
             std::size_t nSteps = 2400000;
             readdy::scalar dt = 4e-5;
@@ -603,250 +603,114 @@ TEMPLATE_TEST_CASE("Helix grows by spatial topology reactions", "[!hide][integra
 }
 
 TEMPLATE_TEST_CASE("Helix grows by structural topology reactions", "[!hide][integration]", SingleCPU, CPU) {
-GIVEN("An initial polymer B-A-A-...-A-C with helical structure") {
-std::vector<readdy::Vec3> initPos23 =
-        {{-1.75373831, -2.14809599, 3.09407703},
-         {-0.75373831, -2.14809599, 3.09407703},
-         {0.13171772,  -1.68337282, 3.09407703},
-         {0.7030635,   -0.86664044, 3.0133787},
-         {0.8416891,   0.09866305,  2.79208227},
-         {0.54051056,  0.97080799,  2.40652464},
-         {-0.09420439, 1.53207468,  1.87537811},
-         {-0.87022492, 1.64486677,  1.25483795},
-         {-1.55890118, 1.2871743,   0.62413906},
-         {-1.95409477, 0.55824634,  0.06513454},
-         {-1.92530725, -0.34698867, -0.35880043},
-         {-1.45131376, -1.18816226, -0.61910247},
-         {-0.62563341, -1.74141669, -0.72938167},
-         {0.36757365,  -1.85710024, -0.74191387},
-         {1.30097023,  -1.49833734, -0.73416743},
-         {1.96263423,  -0.75053257, -0.7888372},
-         {2.21067781,  0.20064083,  -0.97253135},
-         {2.00981645,  1.11709499,  -1.3186043},
-         {1.44046291,  1.76969029,  -1.81856021},
-         {0.67800228,  1.99729206,  -2.42424266},
-         {-0.05241042, 1.74830016,  -3.06024607},
-         {-0.53387995, 1.09394804,  -3.64335016},
-         {-0.61367178, 0.20994353,  -4.10396854}};
-
-readdy::scalar angle = 2. * M_PI / 13;
-readdy::scalar dihedral = -10. * M_PI / 180.;
-
-readdy::model::Context ctx;
-ctx.
-
-boxSize() = {50., 50., 50.};
-
-ctx.
-
-particleTypes()
-
-.add("A", 0.1, readdy::model::particleflavor::TOPOLOGY);
-ctx.
-
-particleTypes()
-
-.add("B", 0.1, readdy::model::particleflavor::TOPOLOGY);
-ctx.
-
-particleTypes()
-
-.add("C", 0.1, readdy::model::particleflavor::TOPOLOGY);
-ctx.
-
-topologyRegistry()
-
-.addType("helix");
-ctx.
-
-topologyRegistry()
-
-.configureBondPotential("A","A",{
-1000., 1.});
-ctx.
-
-topologyRegistry()
-
-.configureBondPotential("B","A",{
-1000., 1.});
-ctx.
-
-topologyRegistry()
-
-.configureBondPotential("C","A",{
-1000., 1.});
-ctx.
-
-topologyRegistry()
-
-.configureAnglePotential("A", "A", "A", {
-1000., M_PI - angle});
-ctx.
-
-topologyRegistry()
-
-.configureAnglePotential("B", "A", "A", {
-1000., M_PI - angle});
-ctx.
-
-topologyRegistry()
-
-.configureAnglePotential("A", "A", "C", {
-1000., M_PI - angle});
-ctx.
-
-topologyRegistry()
-
-.configureTorsionPotential("A", "A", "A", "A", {
-1000., 1., -dihedral});
-ctx.
-
-topologyRegistry()
-
-.configureTorsionPotential("B", "A", "A", "A", {
-1000., 1., -dihedral});
-ctx.
-
-topologyRegistry()
-
-.configureTorsionPotential("A", "A", "A", "C", {
-1000., 1., -dihedral});
-
-namespace rmt = readdy::model::top;
-auto reactionFunction = [&ctx](rmt::GraphTopology &topology) -> rmt::reactions::Recipe {
-    rmt::reactions::Recipe recipe(topology);
-    auto &graph = topology.graph();
-    for (auto vIt = graph.begin(); vIt != graph.end(); ++vIt) {
-        auto p = topology.particleForVertex(vIt.persistent_index());
-        if (p.type() == ctx.particleTypes().idOf("C")) {
-            readdy::Vec3 pos1;
-            for (auto &neighbor : vIt->neighbors()) {
-                pos1 = topology.particleForVertex(neighbor).pos();
+    GIVEN("An initial polymer B-A-A-...-A-C with helical structure") {
+        std::vector<readdy::Vec3> initPos23 = {{-1.75373831, -2.14809599, 3.09407703},
+                                       {-0.75373831, -2.14809599, 3.09407703},
+                                       {0.13171772,  -1.68337282, 3.09407703},
+                                       {0.7030635,   -0.86664044, 3.0133787},
+                                       {0.8416891,   0.09866305,  2.79208227},
+                                       {0.54051056,  0.97080799,  2.40652464},
+                                       {-0.09420439, 1.53207468,  1.87537811},
+                                       {-0.87022492, 1.64486677,  1.25483795},
+                                       {-1.55890118, 1.2871743,   0.62413906},
+                                       {-1.95409477, 0.55824634,  0.06513454},
+                                       {-1.92530725, -0.34698867, -0.35880043},
+                                       {-1.45131376, -1.18816226, -0.61910247},
+                                       {-0.62563341, -1.74141669, -0.72938167},
+                                       {0.36757365,  -1.85710024, -0.74191387},
+                                       {1.30097023,  -1.49833734, -0.73416743},
+                                       {1.96263423,  -0.75053257, -0.7888372},
+                                       {2.21067781,  0.20064083,  -0.97253135},
+                                       {2.00981645,  1.11709499,  -1.3186043},
+                                       {1.44046291,  1.76969029,  -1.81856021},
+                                       {0.67800228,  1.99729206,  -2.42424266},
+                                       {-0.05241042, 1.74830016,  -3.06024607},
+                                       {-0.53387995, 1.09394804,  -3.64335016},
+                                       {-0.61367178, 0.20994353,  -4.10396854}};
+        readdy::scalar angle = 2. * M_PI / 13;
+        readdy::scalar dihedral = -10. * M_PI / 180.;
+        readdy::model::Context ctx;
+        ctx.boxSize() = {50., 50., 50.};
+        ctx.particleTypes().add("A", 0.1, readdy::model::particleflavor::TOPOLOGY);
+        ctx.particleTypes().add("B", 0.1, readdy::model::particleflavor::TOPOLOGY);
+        ctx.particleTypes().add("C", 0.1, readdy::model::particleflavor::TOPOLOGY);
+        ctx.topologyRegistry().addType("helix");
+        ctx.topologyRegistry().configureBondPotential("A", "A", {1000., 1.});
+        ctx.topologyRegistry().configureBondPotential("B", "A", {1000., 1.});
+        ctx.topologyRegistry().configureBondPotential("C", "A", {1000., 1.});
+        ctx.topologyRegistry().configureAnglePotential("A", "A", "A", {1000., M_PI - angle});
+        ctx.topologyRegistry().configureAnglePotential("B", "A", "A", {1000., M_PI - angle});
+        ctx.topologyRegistry().configureAnglePotential("A", "A", "C", {1000., M_PI - angle});
+        ctx.topologyRegistry().configureTorsionPotential("A", "A", "A", "A", {1000., 1., -dihedral});
+        ctx.topologyRegistry().configureTorsionPotential("B", "A", "A", "A", {1000., 1., -dihedral});
+        ctx.topologyRegistry().configureTorsionPotential("A", "A", "A", "C", {1000., 1.,-dihedral});
+        namespace rmt = readdy::model::top;
+        auto reactionFunction = [&ctx](rmt::GraphTopology &topology) -> rmt::reactions::Recipe {
+            rmt::reactions::Recipe recipe(topology);
+            auto &graph = topology.graph();
+            for (auto vIt = graph.begin(); vIt != graph.end(); ++vIt) {
+                auto p = topology.particleForVertex(vIt.persistent_index());
+                if (p.type() == ctx.particleTypes().idOf("C")) {
+                    readdy::Vec3 pos1;
+                    for (auto &neighbor : vIt->neighbors()) { pos1 = topology.particleForVertex(neighbor).pos(); }
+                    auto pos2 = topology.particleForVertex(vIt.persistent_index()).pos();
+                    auto newPosition = pos2 + (pos2 - pos1);
+                    auto ida = ctx.particleTypes().idOf("A");
+                    recipe.changeParticleType(vIt.persistent_index(), ida);
+                    std::string ctype = "C";
+                    recipe.appendNewParticle({vIt.persistent_index()}, ctype, newPosition);
+                }
             }
+            return recipe;
+        };
+        auto rateFunction = [](const rmt::GraphTopology &topology) -> readdy::scalar {
+            auto nVertices = topology.graph().vertices().size();
+            if (nVertices < 43) { return 1e2; } else { return 0.; }
+        };
+        readdy::model::top::reactions::StructuralTopologyReaction reaction("append", reactionFunction, rateFunction);
+        std::string type = "helix";
+        ctx.topologyRegistry().addStructuralReaction(type, reaction);
+        readdy::Simulation simulation(create<TestType>(), ctx);
+        WHEN("the helix elongates by attaching 20 segments from substrate particles") {
+            {
+                std::vector<readdy::model::Particle> topParticles;
+                topParticles.reserve(23);
+                topParticles.emplace_back(initPos23.front(), ctx.particleTypes().idOf("B"));
+                for (std::size_t i = 1; i < initPos23.size() - 1; ++i) {
+                    topParticles.emplace_back(initPos23[i], ctx.particleTypes().idOf("A"));
+                }
+                topParticles.emplace_back(initPos23.back(), ctx.particleTypes().idOf("C"));
+                auto top = simulation.addTopology("helix", topParticles);
+                auto &graph = top->graph();
+                for (std::size_t i = 0; i < topParticles.size() - 1; ++i) {
+                    top->addEdgeBetweenParticles(i, i + 1);
+                }
+            }
+            std::vector<readdy::scalar> distances;
+            auto callback = [&distances, &ctx](const std::vector<readdy::Vec3> &dist) {
+                const auto d = readdy::bcs::dist(dist.at(0), dist.at(1), ctx.boxSize(), ctx.periodicBoundaryConditions());
+                distances.push_back(d);
+            };
+            auto obs = simulation.observe().positions(1000, {"B", "C"}, callback);
 
-            auto pos2 = topology.particleForVertex(vIt.persistent_index()).pos();
-            auto newPosition = pos2 + (pos2 - pos1);
-
-            auto ida = ctx.particleTypes().idOf("A");
-            recipe.changeParticleType(vIt.persistent_index(), ida);
-
-            std::string ctype = "C";
-            recipe.appendNewParticle({vIt.persistent_index()}, ctype, newPosition);
+            simulation.registerObservable(std::move(obs));
+            std::size_t nSteps = 2400000;
+            readdy::scalar dt = 4e-5;
+            simulation.run(nSteps, dt);
+            REQUIRE(!distances.empty());
+            THEN("the average end-to-end distance after absorption of all substrate particles is roughly ~14.4") {
+                /* extract recorded distances after a certain number of steps when all substrates are most likely absorbed */
+                auto n = distances.size();
+                auto first = distances.begin() + 2 * n / 10; /* i.e. after 20% of the time*/
+                std::vector<readdy::scalar> distances2(first, distances.end());
+                auto n2 = distances2.size();
+                auto mean = std::accumulate(distances2.begin(), distances2.end(), 0.);
+                mean /= static_cast<readdy::scalar>(n2);
+                readdy::scalar expected = 14.434;
+                auto relativeErr = std::abs(mean - expected) / expected;
+                /* allow for 5% deviation. Usually the observed mean is expected to deviate about ~0.5% */
+                CHECK(relativeErr < 0.05);
+            }
         }
     }
-    return recipe;
-};
-
-auto rateFunction = [](const rmt::GraphTopology &topology) -> readdy::scalar {
-    auto nVertices = topology.graph().vertices().size();
-    if (nVertices < 43) {
-        return 1e2;
-    } else {
-        return 0.;
-    }
-};
-
-readdy::model::top::reactions::StructuralTopologyReaction reaction("append", reactionFunction, rateFunction);
-std::string type = "helix";
-ctx.
-
-topologyRegistry()
-
-.
-addStructuralReaction(type, reaction
-);
-
-readdy::Simulation simulation(create<TestType>(), ctx);
-WHEN("the helix elongates by attaching 20 segments from substrate particles") {
-{
-std::vector<readdy::model::Particle> topParticles;
-topParticles.reserve(23);
-topParticles.
-emplace_back(initPos23
-.
-
-front(), ctx
-
-.
-
-particleTypes()
-
-.idOf("B"));
-for (
-std::size_t i = 1;
-i<initPos23.
-
-size()
-
-- 1; ++i) {
-topParticles.
-emplace_back(initPos23[i], ctx
-.
-
-particleTypes()
-
-.idOf("A"));
-}
-topParticles.
-emplace_back(initPos23
-.
-
-back(), ctx
-
-.
-
-particleTypes()
-
-.idOf("C"));
-auto top = simulation.addTopology("helix", topParticles);
-auto &graph = top->graph();
-for (
-std::size_t i = 0;
-i<topParticles.
-
-size()
-
--1; ++i) {
-top->
-addEdgeBetweenParticles(i, i
-+ 1);
-}
-}
-
-auto obs = simulation.observe().positions(1000, {"B", "C"});
-std::vector<readdy::scalar> distances;
-auto callback = [&distances, &ctx](const std::vector<readdy::Vec3> &dist) {
-    const auto d = readdy::bcs::dist(dist.at(0), dist.at(1), ctx.boxSize(),
-                                     ctx.periodicBoundaryConditions());
-    distances.push_back(d);
-};
-simulation.
-registerObservable(std::move(obs), callback
-);
-
-std::size_t nSteps = 2400000;
-readdy::scalar dt = 4e-5;
-simulation.
-run(nSteps, dt
-);
-
-REQUIRE(!distances.empty());
-
-THEN("the average end-to-end distance after absorption of all substrate particles is roughly ~14.4") {
-// extract recorded distances after a certain number of steps
-// when all substrates are most likely absorbed
-auto n = distances.size();
-auto first = distances.begin() + 2 * n / 10; // i.e. after 20% of the time
-std::vector<readdy::scalar> distances2(first, distances.end());
-auto n2 = distances2.size();
-auto mean = std::accumulate(distances2.begin(), distances2.end(), 0.);
-mean /= static_cast
-<readdy::scalar>(n2);
-readdy::scalar expected = 14.434;
-auto relativeErr = std::abs(mean - expected) / expected;
-// allow for 5% deviation. Usually the observed mean is expected to deviate about ~0.5%
-CHECK(relativeErr < 0.05);
-}
-}
-}
 }

--- a/readdy/test/TestContext.cpp
+++ b/readdy/test/TestContext.cpp
@@ -471,4 +471,25 @@ TEST_CASE("Test context.", "[context]") {
             }
         }
     }
+
+    SECTION("Test set kernel configuration") {
+        Context ctx;
+        WHEN("string is not valid json string (has missing braces)") {
+            std::string invalid = R"({"MPI":{"dx":4.9,"dy":4.9,"dz":4.9,"haloThickness":1.0})";
+            THEN("there must be an error") {
+                REQUIRE_THROWS(ctx.setKernelConfiguration(invalid));
+            }
+        }
+        WHEN("string is valid") {
+            std::string valid = R"({"MPI":{"dx":4.9,"dy":5.9,"dz":6.9,"haloThickness":1.0}})";
+            THEN("everything's OK and the appropriate values are set") {
+                ctx.setKernelConfiguration(valid);
+                auto& cfg = ctx.kernelConfiguration();
+                REQUIRE(cfg.mpi.dx == Approx(4.9));
+                REQUIRE(cfg.mpi.dy == Approx(5.9));
+                REQUIRE(cfg.mpi.dz == Approx(6.9));
+                REQUIRE(cfg.mpi.haloThickness == Approx(1.0));
+            }
+        }
+    }
 }

--- a/readdy/test/TestDetailedBalance.cpp
+++ b/readdy/test/TestDetailedBalance.cpp
@@ -385,8 +385,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idForward = ctx.reactions().idOf("convAB");
             const auto idBackward = ctx.reactions().idOf("convBA");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1, [&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -394,15 +393,14 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 }
                 REQUIRE(counts.at(idBackward) == 0);
                 REQUIRE(counts.at(idForward) == 0);
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 REQUIRE(result[0] + result[1] == 1); // conservation of A + B
                 REQUIRE(result[2] == 500); // conservation of D
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto ida = ctx.particleTypes().idOf("A");
@@ -428,8 +426,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idForward = ctx.reactions().idOf("convAB");
             const auto idBackward = ctx.reactions().idOf("convBA");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1,[&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -437,15 +434,14 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 }
                 REQUIRE(counts.at(idBackward) == 0);
                 REQUIRE(counts.at(idForward) == 1);
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 REQUIRE(result[0] + result[1] == 1); // conservation of A + B
                 REQUIRE(result[2] == 500); // conservation of D
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto ida = ctx.particleTypes().idOf("A");
@@ -475,8 +471,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idfus = ctx.reactions().idOf("fusion");
             const auto idfis = ctx.reactions().idOf("fission");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1,[&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -484,19 +479,18 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 }
                 REQUIRE(counts.at(idfus) == 1); // fusion must occur
                 REQUIRE(counts.at(idfis) == 0); // fission shall not occur
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "C", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 REQUIRE(result[0] + result[2] == 1); // conservation of A + C
                 REQUIRE(result[1] + result[2] == 1); // conservation of B + C
                 REQUIRE(result[3] == 500); // conservation of D
                 if (result[0] + result[2] != 1) {
                     readdy::log::trace("A {} B {} C {}", result[0], result[1], result[2]);
                 }
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto ida = ctx.particleTypes().idOf("A");
@@ -523,8 +517,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idfus = ctx.reactions().idOf("fusion");
             const auto idfis = ctx.reactions().idOf("fission");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1,[&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -534,12 +527,11 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 REQUIRE(counts.at(idfus) == 0);
                 // fission shall not occur
                 REQUIRE(counts.at(idfis) == 0);
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "C", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 // conservation of A + C
                 REQUIRE(result[0] + result[2] == 1);
                 // conservation of B + C
@@ -549,7 +541,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 if (result[0] + result[2] != 1) {
                     readdy::log::trace("A {} B {} C {}", result[0], result[1], result[2]);
                 }
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto ida = ctx.particleTypes().idOf("A");
@@ -580,8 +572,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idfus = ctx.reactions().idOf("fusion");
             const auto idfis = ctx.reactions().idOf("fission");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1, [&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -589,19 +580,18 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 }
                 REQUIRE(counts.at(idfis) == 1); // fission must occur
                 REQUIRE(counts.at(idfus) == 0); // fusion shall not occur
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "C", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 REQUIRE(result[0] + result[2] == 1); // conservation of A + C
                 REQUIRE(result[1] + result[2] == 1); // conservation of B + C
                 REQUIRE(result[3] == 500); // conservation of D
                 if (result[0] + result[2] != 1) {
                     readdy::log::trace("A {} B {} C {}", result[0], result[1], result[2]);
                 }
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto idc = ctx.particleTypes().idOf("C");
@@ -627,8 +617,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idfus = ctx.reactions().idOf("fusion");
             const auto idfis = ctx.reactions().idOf("fission");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1,[&idfus, &idfis](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -636,19 +625,18 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 }
                 REQUIRE(counts.at(idfis) == 0); // fission shall not occur
                 REQUIRE(counts.at(idfus) == 0); // fusion shall not occur
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "C", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 REQUIRE(result[0] + result[2] == 1); // conservation of A + C
                 REQUIRE(result[1] + result[2] == 1); // conservation of B + C
                 REQUIRE(result[3] == 500); // conservation of D
                 if (result[0] + result[2] != 1) {
                     readdy::log::trace("A {} B {} C {}", result[0], result[1], result[2]);
                 }
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto idc = ctx.particleTypes().idOf("C");
@@ -677,8 +665,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idForward = ctx.reactions().idOf("convAB");
             const auto idBackward = ctx.reactions().idOf("convBA");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1, [&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -686,16 +673,15 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 }
                 REQUIRE(counts.at(idBackward) == 0);
                 REQUIRE(counts.at(idForward) == 1);
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "C", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 REQUIRE(result[0] + result[1] == 1); // conservation of A + B
                 REQUIRE(result[2] == 1); // conservation of C
                 REQUIRE(result[3] == 500); // conservation of D
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto ida = ctx.particleTypes().idOf("A");
@@ -722,8 +708,7 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
             const auto idForward = ctx.reactions().idOf("convAB");
             const auto idBackward = ctx.reactions().idOf("convBA");
 
-            auto countsObs = kernel->observe().reactionCounts(1);
-            countsObs->callback() = [&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
+            auto countsObs = kernel->observe().reactionCounts(1,[&idForward, &idBackward](const readdy::model::observables::ReactionCounts::result_type &result) {
                 const auto& counts = std::get<0>(result);
                 if (counts.empty()) {
                     readdy::log::trace("reaction counts is empty, no reaction handler ran so far, skip test");
@@ -731,16 +716,15 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
                 }
                 REQUIRE(counts.at(idBackward) == 0);
                 REQUIRE(counts.at(idForward) == 0);
-            };
+            });
             auto countsConnection = kernel->connectObservable(countsObs.get());
 
             std::vector<std::string> typesToCount = {"A", "B", "C", "D"};
-            auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-            numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+            auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
                 REQUIRE(result[0] + result[1] == 1); // conservation of A + B
                 REQUIRE(result[2] == 1); // conservation of C
                 REQUIRE(result[3] == 500); // conservation of D
-            };
+            });
             auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
             const auto ida = ctx.particleTypes().idOf("A");
@@ -765,14 +749,13 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
         ctx.reactions().addFission("fission", "C", "A", "B", 2, reactionRadius);
 
         std::vector<std::string> typesToCount = {"A", "B", "C"};
-        auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-        numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+        auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
             REQUIRE(result[0] + result[2] == 20); // conservation of A + C
             REQUIRE(result[1] + result[2] == 20); // conservation of B + C
             if (result[0] + result[2] != 1) {
                 readdy::log::trace("A {} B {} C {}", result[0], result[1], result[2]);
             }
-        };
+        });
         auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
         const auto ida = ctx.particleTypes().idOf("A");
@@ -799,10 +782,9 @@ TEMPLATE_TEST_CASE("Detailed balance integration tests.", "[detailed-balance]", 
         // A + B + 2*C = const
 
         std::vector<std::string> typesToCount = {"A", "B", "C"};
-        auto numbersObs = kernel->observe().nParticles(1, typesToCount);
-        numbersObs->callback() = [](const readdy::model::observables::NParticles::result_type &result) {
+        auto numbersObs = kernel->observe().nParticles(1, typesToCount, [](const readdy::model::observables::NParticles::result_type &result) {
             REQUIRE(result[0] + result[1] + 2*result[2] == 40); // conservation of A + B + 2C
-        };
+        });
         auto numbersConnection = kernel->connectObservable(numbersObs.get());
 
         const auto ida = ctx.particleTypes().idOf("A");

--- a/readdy/test/TestObservables.cpp
+++ b/readdy/test/TestObservables.cpp
@@ -178,7 +178,7 @@ TEMPLATE_TEST_CASE("Test observables", "[observables]", SingleCPU, CPU) {
             std::size_t n_time_steps = 500;
 
             auto obs = kernel->observe().topologies(1);
-            obs->callback() = ([&](const readdy::model::observables::Topologies::result_type &value) {
+            obs->setCallback([&](const readdy::model::observables::Topologies::result_type &value) {
                 auto tops = kernel->stateModel().getTopologies();
                 REQUIRE(value.size() == tops.size());
                 for (auto its = std::make_pair(tops.begin(), value.begin());

--- a/readdy/test/TestPotentials.cpp
+++ b/readdy/test/TestPotentials.cpp
@@ -109,7 +109,7 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             readdy::Vec3 lowerBound{static_cast<readdy::scalar>(-2.5), static_cast<readdy::scalar>(-2.5),
                                     static_cast<readdy::scalar>(-2.5)},
                     upperBound{2.5, 2.5, 2.5};
-            ppObs->callback() = [lowerBound, upperBound](readdy::model::observables::Positions::result_type currentResult) {
+            ppObs->setCallback([lowerBound, upperBound](readdy::model::observables::Positions::result_type currentResult) {
                 readdy::Vec3 avg{0, 0, 0};
                 bool allWithinBounds = true;
                 for (auto &&v : currentResult) {
@@ -119,7 +119,7 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
                 avg /= currentResult.size();
                 if (!allWithinBounds) readdy::log::debug("Average position: {}", avg);
                 REQUIRE(allWithinBounds);
-            };
+            });
             auto connection = kernel->connectObservable(ppObs.get());
             run(*kernel, timeStep);
         }
@@ -150,7 +150,7 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             auto ppObs = kernel->observe().positions(1);
             const readdy::scalar maxDistFromOrigin = 4.0; // at kbt=1 and force_const=20 the RMSD in a well potential would be ~0.2
             const readdy::scalar maxDistFromOriginSquared = maxDistFromOrigin * maxDistFromOrigin;
-            ppObs->callback() = [maxDistFromOriginSquared](readdy::model::observables::Positions::result_type currentResult) {
+            ppObs->setCallback([maxDistFromOriginSquared](readdy::model::observables::Positions::result_type currentResult) {
                 readdy::Vec3 avg{0, 0, 0};
                 bool allWithinBounds = true;
                 for (auto &&v : currentResult) {
@@ -161,7 +161,7 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
                 avg /= currentResult.size();
                 if (!allWithinBounds) readdy::log::debug("Average position: {}", avg);
                 REQUIRE(allWithinBounds);
-            };
+            });
             auto connection = kernel->connectObservable(ppObs.get());
             run(*kernel, timeStep);
         }
@@ -181,17 +181,17 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             // record ids to get data-structure-indexes of the two particles later on
             auto pObs = kernel->observe().particles(1);
             std::vector<readdy::ParticleId> ids;
-            pObs->callback() = [&ids](const readdy::model::observables::Particles::result_type &result) {
+            pObs->setCallback([&ids](const readdy::model::observables::Particles::result_type &result) {
                 const auto &recordedIds = std::get<1>(result);
                 ids.insert(ids.end(), recordedIds.begin(), recordedIds.end());
-            };
+            });
             auto connParticles = kernel->connectObservable(pObs.get());
             // also record forces
             auto fObs = kernel->observe().forces(1);
             std::vector<readdy::Vec3> collectedForces;
-            fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+            fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
                 collectedForces.insert(collectedForces.end(), result.begin(), result.end());
-            };
+            });
             auto conn = kernel->connectObservable(fObs.get());
 
             // calc forces
@@ -228,17 +228,17 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             // record ids to get data-structure-indexes of the two particles later on
             auto pObs = kernel->observe().particles(1);
             std::vector<readdy::ParticleId> ids;
-            pObs->callback() = [&ids](const readdy::model::observables::Particles::result_type &result) {
+            pObs->setCallback([&ids](const readdy::model::observables::Particles::result_type &result) {
                 const auto &recordedIds = std::get<1>(result);
                 ids.insert(ids.end(), recordedIds.begin(), recordedIds.end());
-            };
+            });
             auto connParticles = kernel->connectObservable(pObs.get());
             // also record forces
             auto fObs = kernel->observe().forces(1);
             std::vector<readdy::Vec3> collectedForces;
-            fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+            fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
                 collectedForces.insert(collectedForces.end(), result.begin(), result.end());
-            };
+            });
             auto connForces = kernel->connectObservable(fObs.get());
 
             kernel->initialize();
@@ -275,17 +275,17 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             // record ids to get data-structure-indexes of the two particles later on
             auto pObs = kernel->observe().particles(1);
             std::vector<readdy::ParticleId> ids;
-            pObs->callback() = [&ids](const readdy::model::observables::Particles::result_type &result) {
+            pObs->setCallback([&ids](const readdy::model::observables::Particles::result_type &result) {
                 const auto &recordedIds = std::get<1>(result);
                 ids.insert(ids.end(), recordedIds.begin(), recordedIds.end());
-            };
+            });
             auto connParticles = kernel->connectObservable(pObs.get());
             // also record forces
             auto fObs = kernel->observe().forces(1);
             std::vector<readdy::Vec3> collectedForces;
-            fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+            fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
                 collectedForces.insert(collectedForces.end(), result.begin(), result.end());
-            };
+            });
             auto connForces = kernel->connectObservable(fObs.get());
 
             kernel->initialize();
@@ -333,17 +333,17 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             // record ids to get data-structure-indexes of the two particles later on
             auto pObs = kernel->observe().particles(1);
             std::vector<readdy::ParticleId> ids;
-            pObs->callback() = [&ids](const readdy::model::observables::Particles::result_type &result) {
+            pObs->setCallback([&ids](const readdy::model::observables::Particles::result_type &result) {
                 const auto &recordedIds = std::get<1>(result);
                 ids.insert(ids.end(), recordedIds.begin(), recordedIds.end());
-            };
+            });
             auto connParticles = kernel->connectObservable(pObs.get());
             // also record forces
             auto fObs = kernel->observe().forces(1);
             std::vector<readdy::Vec3> collectedForces;
-            fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+            fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
                 collectedForces.insert(collectedForces.end(), result.begin(), result.end());
-            };
+            });
             auto connForces = kernel->connectObservable(fObs.get());
 
             kernel->initialize();
@@ -398,17 +398,17 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             // record ids
             auto pObs = kernel->observe().particles(1);
             std::vector<readdy::ParticleId> ids;
-            pObs->callback() = [&ids](const readdy::model::observables::Particles::result_type& result) {
+            pObs->setCallback([&ids](const readdy::model::observables::Particles::result_type& result) {
                 const auto& recordedIds = std::get<1>(result);
                 ids.insert(ids.end(), recordedIds.begin(), recordedIds.end());
-            };
+            });
             auto connParticles = kernel->connectObservable(pObs.get());
             // also record forces
             auto fObs = kernel->observe().forces(1);
             std::vector<readdy::Vec3> collectedForces;
-            fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type& result) {
+            fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type& result) {
                 collectedForces.insert(collectedForces.end(), result.begin(), result.end());
-            };
+            });
             auto conn = kernel->connectObservable(fObs.get());
 
             // we need to update the neighbor list as this is a pair potential
@@ -465,17 +465,17 @@ TEMPLATE_TEST_CASE("Test potentials", "[potentials]", SingleCPU, CPU) {
             // record ids to get data-structure-indexes of the two particles later on
             auto pObs = kernel->observe().particles(1);
             std::vector<readdy::ParticleId> ids;
-            pObs->callback() = [&ids](const readdy::model::observables::Particles::result_type &result) {
+            pObs->setCallback([&ids](const readdy::model::observables::Particles::result_type &result) {
                 const auto &recordedIds = std::get<1>(result);
                 ids.insert(ids.end(), recordedIds.begin(), recordedIds.end());
-            };
+            });
             auto connParticles = kernel->connectObservable(pObs.get());
             // also record forces
             auto fObs = kernel->observe().forces(1);
             std::vector<readdy::Vec3> collectedForces;
-            fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+            fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
                 collectedForces.insert(collectedForces.end(), result.begin(), result.end());
-            };
+            });
             auto conn = kernel->connectObservable(fObs.get());
 
             // we need to update the neighbor list as this is a pair potential

--- a/readdy/test/TestReactions.cpp
+++ b/readdy/test/TestReactions.cpp
@@ -104,12 +104,12 @@ TEMPLATE_TEST_CASE("Test reaction handlers", "[reactions]", SingleCPU, CPU) {
 
                 auto obs = kernel->observe().nParticles(1, std::vector<std::string>({"A", "B", "AB"}));
                 auto conn = kernel->connectObservable(obs.get());
-                obs->callback() = [&n_A, &n_B](const n_particles_obs::result_type &result) {
+                obs->setCallback([&n_A, &n_B](const n_particles_obs::result_type &result) {
                     if (result.size() == 2) {
                         REQUIRE(n_A == result[0] + result[2]);
                         REQUIRE(n_B == result[1] + result[2]);
                     }
-                };
+                });
 
                 readdy::api::SimulationLoop loop(kernel.get(), 1);
                 loop.useReactionScheduler(handler);
@@ -141,21 +141,20 @@ TEMPLATE_TEST_CASE("Test reaction handlers", "[reactions]", SingleCPU, CPU) {
                 }
 
                 auto obs = kernel->observe().positions(1, std::vector<std::string>({"F"}));
-                obs->callback() =
-                        [&](const readdy::model::observables::Positions::result_type &result) {
-                            std::set<readdy::Vec3, Vec3ProjectedLess> checklist;
-                            for (const auto &pos : result) {
-                                checklist.emplace(pos);
-                            }
-                            REQUIRE(fPositions.size() == checklist.size());
-                            auto itPos = fPositions.begin();
-                            auto itCheck = checklist.begin();
-                            while (itPos != fPositions.end()) {
-                                readdy::testing::vec3eq(*itPos, *itCheck, kernel->doublePrecision() ? 1e-8 : 1e-6);
-                                ++itPos;
-                                ++itCheck;
-                            }
-                        };
+                obs->setCallback([&](const readdy::model::observables::Positions::result_type &result) {
+                    std::set<readdy::Vec3, Vec3ProjectedLess> checklist;
+                    for (const auto &pos : result) {
+                        checklist.emplace(pos);
+                    }
+                    REQUIRE(fPositions.size() == checklist.size());
+                    auto itPos = fPositions.begin();
+                    auto itCheck = checklist.begin();
+                    while (itPos != fPositions.end()) {
+                        readdy::testing::vec3eq(*itPos, *itCheck, kernel->doublePrecision() ? 1e-8 : 1e-6);
+                        ++itPos;
+                        ++itCheck;
+                    }
+                });
                 auto connection = kernel->connectObservable(obs.get());
                 {
                     readdy::api::SimulationLoop loop(kernel.get(), .1);

--- a/readdy/test/TestSimulationLoop.cpp
+++ b/readdy/test/TestSimulationLoop.cpp
@@ -37,6 +37,7 @@
  * @file TestSimulationLoop.cpp
  * @author clonker
  * @author chrisfro**
+ * @todo test checkpointing https://en.cppreference.com/w/cpp/filesystem/temp_directory_path
  * @date 23.08.16
  */
 
@@ -52,7 +53,6 @@
 namespace api = readdy::api;
 
 using namespace readdytesting::kernel;
-
 
 TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
     SECTION("Correct number of timesteps") {

--- a/readdy/test/TestSimulationLoop.cpp
+++ b/readdy/test/TestSimulationLoop.cpp
@@ -37,7 +37,6 @@
  * @file TestSimulationLoop.cpp
  * @author clonker
  * @author chrisfro**
- * @todo test checkpointing https://en.cppreference.com/w/cpp/filesystem/temp_directory_path
  * @date 23.08.16
  */
 
@@ -62,7 +61,7 @@ TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
         auto increment = [&counter](readdy::model::observables::NParticles::result_type result) {
             counter++;
         };
-        auto obsHandle = simulation.registerObservable(simulation.observe().nParticles(1), increment);
+        auto obsHandle = simulation.registerObservable(simulation.observe().nParticles(1, increment));
         simulation.run(3, 0.1);
         REQUIRE(counter == 4);
     }
@@ -73,7 +72,7 @@ TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
         auto increment = [&counter](readdy::model::observables::NParticles::result_type result) {
             counter++;
         };
-        auto obsHandle = simulation.registerObservable(simulation.observe().nParticles(1), increment);
+        auto obsHandle = simulation.registerObservable(simulation.observe().nParticles(1, increment));
         auto shallContinue = [](readdy::TimeStep currentStep) {
             return currentStep < 5;
         };
@@ -97,7 +96,7 @@ TEMPLATE_TEST_CASE("Test simulation loop", "[loop]", SingleCPU, CPU) {
                 doStop = true;
             }
         };
-        auto obsHandle = simulation.registerObservable(simulation.observe().nParticles(1), increment);
+        auto obsHandle = simulation.registerObservable(simulation.observe().nParticles(1, increment));
         auto shallContinue = [&doStop](readdy::TimeStep currentStep) {
             return !doStop;
         };

--- a/readdy/test/TestTopologies.cpp
+++ b/readdy/test/TestTopologies.cpp
@@ -106,11 +106,11 @@ TEMPLATE_TEST_CASE("Test topologies.", "[topologies]", SingleCPU, CPU) {
         }
         auto fObs = kernel->observe().forces(1);
         std::vector<readdy::Vec3> collectedForces;
-        fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+        fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
             for (const auto &force : result) {
                 collectedForces.push_back(force);
             }
-        };
+        });
 
         auto conn = kernel->connectObservable(fObs.get());
 
@@ -152,11 +152,11 @@ TEMPLATE_TEST_CASE("Test topologies.", "[topologies]", SingleCPU, CPU) {
         }
         auto fObs = kernel->observe().forces(1);
         std::vector<readdy::Vec3> collectedForces;
-        fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+        fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
             for (const auto &force : result) {
                 collectedForces.push_back(force);
             }
-        };
+        });
 
         auto conn = kernel->connectObservable(fObs.get());
 
@@ -190,11 +190,11 @@ TEMPLATE_TEST_CASE("Test topologies.", "[topologies]", SingleCPU, CPU) {
         }
         auto fObs = kernel->observe().forces(1);
         std::vector<readdy::Vec3> collectedForces;
-        fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+        fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
             for (const auto &force : result) {
                 collectedForces.push_back(force);
             }
-        };
+        });
 
         auto conn = kernel->connectObservable(fObs.get());
 
@@ -248,11 +248,11 @@ TEMPLATE_TEST_CASE("Test topologies.", "[topologies]", SingleCPU, CPU) {
         }
         auto fObs = kernel->observe().forces(1);
         std::vector<readdy::Vec3> collectedForces;
-        fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+        fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
             for (const auto &force : result) {
                 collectedForces.push_back(force);
             }
-        };
+        });
 
         auto conn = kernel->connectObservable(fObs.get());
         auto calculateForces = kernel->actions().calculateForces();
@@ -286,11 +286,11 @@ TEMPLATE_TEST_CASE("Test topologies.", "[topologies]", SingleCPU, CPU) {
         }
         auto fObs = kernel->observe().forces(1);
         std::vector<readdy::Vec3> collectedForces;
-        fObs->callback() = [&collectedForces](const readdy::model::observables::Forces::result_type &result) {
+        fObs->setCallback([&collectedForces](const readdy::model::observables::Forces::result_type &result) {
             for (const auto &force : result) {
                 collectedForces.push_back(force);
             }
-        };
+        });
 
         auto conn = kernel->connectObservable(fObs.get());
         auto calculateForces = kernel->actions().calculateForces();

--- a/wrappers/python/src/cxx/api/ApiModule.cpp
+++ b/wrappers/python/src/cxx/api/ApiModule.cpp
@@ -193,7 +193,7 @@ void exportApi(py::module &api) {
 
         // strictly not an action
         py::class_<MkCkpt>(actionsModule, "MakeCheckpoint").def("__call__", &MkCkpt::perform);
-        simulation.def("create_action_make_checkpoint", [](sim &self, const std::string &basePath, std::size_t maxNSaves) -> std::unique_ptr<MkCkpt> { return self.actions().makeCheckpoint(basePath, maxNSaves); });
+        simulation.def("create_action_make_checkpoint", [](sim &self, const std::string &basePath, std::size_t maxNSaves, const std::string &checkpointFormat) -> std::unique_ptr<MkCkpt> { return self.actions().makeCheckpoint(basePath, maxNSaves, checkpointFormat); });
     }
 
     struct nodelete {

--- a/wrappers/python/src/cxx/api/ExportLoopApi.cpp
+++ b/wrappers/python/src/cxx/api/ExportLoopApi.cpp
@@ -111,9 +111,8 @@ void exportLoopApi(pybind11::module &module) {
             .def("evaluate_observables", &Loop::evaluateObservables, "evaluate"_a)
             .def_property("neighbor_list_cutoff", [](const Loop &self) { return self.neighborListCutoff(); },
                           [](Loop &self, readdy::scalar distance) { self.neighborListCutoff() = distance; })
-            .def("make_checkpoints", [](Loop &self, std::shared_ptr<Saver> saver, std::size_t stride) {
-                self.setSaver(saver);
-                self.setCheckpointingStride(stride);
+            .def("make_checkpoints", [](Loop &self, std::size_t stride, std::string basePath, std::size_t maxNSaves, std::string checkpointFormat) {
+                self.makeCheckpoints(stride, basePath, maxNSaves, checkpointFormat);
             })
             .def("describe", &Loop::describe)
             .def("validate", &Loop::validate);

--- a/wrappers/python/src/cxx/api/ExportObservables.h
+++ b/wrappers/python/src/cxx/api/ExportObservables.h
@@ -142,7 +142,7 @@ registerObservable_Positions(sim &self, readdy::Stride stride,
         auto obs = self.observe().positions(stride, types);
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Positions::result_type)>(callbackFun);
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::Positions::result_type&)>(callbackFun);
         auto obs = self.observe().positions(stride, types, pyFun);
         return self.registerObservable(std::move(obs));
     }
@@ -192,7 +192,7 @@ registerObservable_RadialDistribution(sim &self, readdy::Stride stride, py::arra
         auto obs = self.observe().radialDistribution(stride, binBordersVec, typeCountFrom, typeCountTo, particleToDensity);
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::RadialDistribution::result_type)>(
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::RadialDistribution::result_type&)>(
                 callbackFun);
         auto obs = self.observe().radialDistribution(stride, binBordersVec, typeCountFrom, typeCountTo, particleToDensity, pyFun);
         return self.registerObservable(std::move(obs));
@@ -215,7 +215,7 @@ registerObservable_HistogramAlongAxisObservable(sim &self, readdy::Stride stride
         auto obs = self.observe().histogramAlongAxis(stride, binBordersVec, std::move(types), axis);
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::HistogramAlongAxis::result_type)>(callbackFun);
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::HistogramAlongAxis::result_type&)>(callbackFun);
         auto obs = self.observe().histogramAlongAxis(stride, binBordersVec, std::move(types), axis, pyFun);
         return self.registerObservable(std::move(obs));
     }
@@ -228,7 +228,7 @@ registerObservable_NParticles(sim &self, readdy::Stride stride, std::vector<std:
         auto obs = self.observe().nParticles(stride, std::move(types));
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::NParticles::result_type)>(callbackFun);
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::NParticles::result_type&)>(callbackFun);
         auto obs = self.observe().nParticles(stride, std::move(types), pyFun);
         return self.registerObservable(std::move(obs));
     }
@@ -240,7 +240,7 @@ inline obs_handle_t registerObservable_ForcesObservable(sim &self, readdy::Strid
         auto obs = self.observe().forces(stride, std::move(types));
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Forces::result_type)>(callbackFun);
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::Forces::result_type&)>(callbackFun);
         auto obs = self.observe().forces(stride, std::move(types), pyFun);
         return self.registerObservable(std::move(obs));
     }
@@ -251,7 +251,7 @@ inline obs_handle_t registerObservable_Energy(sim &self, readdy::Stride stride, 
         auto obs = self.observe().energy(stride);
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Energy::result_type)>(callbackFun);
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::Energy::result_type&)>(callbackFun);
         auto obs = self.observe().energy(stride, pyFun);
         return self.registerObservable(std::move(obs));
     }
@@ -263,7 +263,7 @@ inline obs_handle_t registerObservable_Virial(sim &self, readdy::Stride stride,
         auto obs = self.observe().virial(stride);
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Virial::result_type)>(callback);
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::Virial::result_type&)>(callback);
         auto obs = self.observe().virial(stride, pyFun);
         return self.registerObservable(std::move(obs));
     }

--- a/wrappers/python/src/cxx/api/ExportObservables.h
+++ b/wrappers/python/src/cxx/api/ExportObservables.h
@@ -59,8 +59,8 @@ using obs_handle_t = readdy::ObservableHandle;
 
 inline obs_handle_t registerObservable_Reactions(sim &self, readdy::Stride stride,
                                                  const py::object& callback = py::none()) {
-    auto obs = self.observe().reactions(stride);
     if (callback.is_none()) {
+        auto obs = self.observe().reactions(stride);
         return self.registerObservable(std::move(obs));
     } else {
         auto internalCallback = [&self, callback](const readdy::model::observables::Reactions::result_type &reactions) mutable {
@@ -79,25 +79,28 @@ inline obs_handle_t registerObservable_Reactions(sim &self, readdy::Stride strid
             }
             callback(converted);
         };
-        return self.registerObservable(std::move(obs), internalCallback);
+        auto obs = self.observe().reactions(stride, internalCallback);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t registerObservable_Topologies(sim &self, readdy::Stride stride,
                                                   const py::object &callback = py::none()) {
-    auto obs = self.observe().topologies(stride);
     if(callback.is_none()) {
+        auto obs = self.observe().topologies(stride);
         return self.registerObservable(std::move(obs));
     } else {
-        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Topologies::result_type)>(callback);
-        return self.registerObservable(std::move(obs), pyFun);
+        auto pyFun = readdy::rpy::PyFunction<void(const readdy::model::observables::Topologies::result_type&)>(callback);
+        auto obs = self.observe().topologies(stride, pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t registerObservable_ReactionCounts(sim &self, readdy::Stride stride,
                                                       const py::object& callback = py::none()) {
-    auto obs = self.observe().reactionCounts(stride);
+
     if (callback.is_none()) {
+        auto obs = self.observe().reactionCounts(stride);
         return self.registerObservable(std::move(obs));
     } else {
         auto internalCallback = [&self, callback](const readdy::model::observables::ReactionCounts::result_type &result) mutable {
@@ -127,26 +130,28 @@ inline obs_handle_t registerObservable_ReactionCounts(sim &self, readdy::Stride 
 
             callback(std::make_tuple(converted, convertedSpatial, convertedStructural));
         };
-        return self.registerObservable(std::move(obs), internalCallback);
+        auto obs = self.observe().reactionCounts(stride, internalCallback);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t
 registerObservable_Positions(sim &self, readdy::Stride stride,
                              const std::vector<std::string> &types, const pybind11::object& callbackFun = py::none()) {
-    auto obs = self.observe().positions(stride, types);
     if (callbackFun.is_none()) {
+        auto obs = self.observe().positions(stride, types);
         return self.registerObservable(std::move(obs));
     } else {
         auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Positions::result_type)>(callbackFun);
-        return self.registerObservable(std::move(obs), pyFun);
+        auto obs = self.observe().positions(stride, types, pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t registerObservable_Particles(sim &self, readdy::Stride stride,
                                                  const pybind11::object& callbackFun = py::none()) {
-    auto obs = self.observe().particles(stride);
     if (callbackFun.is_none()) {
+        auto obs = self.observe().particles(stride);
         return self.registerObservable(std::move(obs));
     } else {
         auto internalCallback = [&self, callbackFun](const readdy::model::observables::Particles::result_type &r) mutable {
@@ -166,7 +171,8 @@ inline obs_handle_t registerObservable_Particles(sim &self, readdy::Stride strid
             }
             callbackFun(result);
         };
-        return self.registerObservable(std::move(obs), internalCallback);
+        auto obs = self.observe().particles(stride, internalCallback);
+        return self.registerObservable(std::move(obs));
     }
 }
 
@@ -179,14 +185,17 @@ registerObservable_RadialDistribution(sim &self, readdy::Stride stride, py::arra
     std::vector<readdy::scalar> binBordersVec{};
     binBordersVec.reserve(static_cast<std::size_t>(info.shape[0]));
     const auto data = static_cast<readdy::scalar *>(info.ptr);
-    for (auto i = 0; i < info.shape[0]; ++i) binBordersVec.push_back(data[i]);
-    auto obs = self.observe().radialDistribution(stride, binBordersVec, typeCountFrom, typeCountTo, particleToDensity);
+    for (auto i = 0; i < info.shape[0]; ++i) {
+        binBordersVec.push_back(data[i]);
+    }
     if (callbackFun.is_none()) {
+        auto obs = self.observe().radialDistribution(stride, binBordersVec, typeCountFrom, typeCountTo, particleToDensity);
         return self.registerObservable(std::move(obs));
     } else {
         auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::RadialDistribution::result_type)>(
                 callbackFun);
-        return self.registerObservable(std::move(obs), pyFun);
+        auto obs = self.observe().radialDistribution(stride, binBordersVec, typeCountFrom, typeCountTo, particleToDensity, pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 
@@ -202,56 +211,61 @@ registerObservable_HistogramAlongAxisObservable(sim &self, readdy::Stride stride
     for (auto i = 0; i < sizeBorders; ++i) {
         binBordersVec.push_back(binBordersData[i]);
     }
-    auto obs = self.observe().histogramAlongAxis(stride, binBordersVec, std::move(types), axis);
     if (callbackFun.is_none()) {
+        auto obs = self.observe().histogramAlongAxis(stride, binBordersVec, std::move(types), axis);
         return self.registerObservable(std::move(obs));
     } else {
-        auto f = readdy::rpy::PyFunction<void(readdy::model::observables::HistogramAlongAxis::result_type)>(callbackFun);
-        return self.registerObservable(std::move(obs), f);
+        auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::HistogramAlongAxis::result_type)>(callbackFun);
+        auto obs = self.observe().histogramAlongAxis(stride, binBordersVec, std::move(types), axis, pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t
 registerObservable_NParticles(sim &self, readdy::Stride stride, std::vector<std::string> types,
                               const py::object &callbackFun = py::none()) {
-    auto obs = self.observe().nParticles(stride, std::move(types));
     if (callbackFun.is_none()) {
+        auto obs = self.observe().nParticles(stride, std::move(types));
         return self.registerObservable(std::move(obs));
     } else {
         auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::NParticles::result_type)>(callbackFun);
-        return self.registerObservable(std::move(obs), pyFun);
+        auto obs = self.observe().nParticles(stride, std::move(types), pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t registerObservable_ForcesObservable(sim &self, readdy::Stride stride, std::vector<std::string> types,
                                                         const py::object& callbackFun = py::none()) {
-    auto obs = self.observe().forces(stride, std::move(types));
     if (callbackFun.is_none()) {
+        auto obs = self.observe().forces(stride, std::move(types));
         return self.registerObservable(std::move(obs));
     } else {
         auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Forces::result_type)>(callbackFun);
-        return self.registerObservable(std::move(obs), pyFun);
+        auto obs = self.observe().forces(stride, std::move(types), pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t registerObservable_Energy(sim &self, readdy::Stride stride, const py::object &callbackFun = py::none()) {
-    auto obs = self.observe().energy(stride);
     if(callbackFun.is_none()) {
+        auto obs = self.observe().energy(stride);
         return self.registerObservable(std::move(obs));
     } else {
         auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Energy::result_type)>(callbackFun);
-        return self.registerObservable(std::move(obs), pyFun);
+        auto obs = self.observe().energy(stride, pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 
 inline obs_handle_t registerObservable_Virial(sim &self, readdy::Stride stride,
                                               const py::object &callback = py::none()) {
-    auto obs = self.observe().virial(stride);
     if(callback.is_none()) {
+        auto obs = self.observe().virial(stride);
         return self.registerObservable(std::move(obs));
     } else {
         auto pyFun = readdy::rpy::PyFunction<void(readdy::model::observables::Virial::result_type)>(callback);
-        return self.registerObservable(std::move(obs), pyFun);
+        auto obs = self.observe().virial(stride, pyFun);
+        return self.registerObservable(std::move(obs));
     }
 }
 

--- a/wrappers/python/src/python/readdy/api/experimental/action_factory.py
+++ b/wrappers/python/src/python/readdy/api/experimental/action_factory.py
@@ -81,8 +81,8 @@ class ActionFactory(object):
     def evaluate_observables(self):
         return self._sim.create_action_evaluate_observables()
 
-    def make_checkpoint(self, base_path, max_n_saves):
-        return self._sim.create_action_make_checkpoint(base_path, max_n_saves)
+    def make_checkpoint(self, base_path, max_n_saves, checkpoint_format):
+        return self._sim.create_action_make_checkpoint(base_path, max_n_saves, checkpoint_format)
 
     def initialize_kernel(self):
         return self._sim.create_action_initialize_kernel()

--- a/wrappers/python/src/python/readdy/api/simulation.py
+++ b/wrappers/python/src/python/readdy/api/simulation.py
@@ -86,8 +86,12 @@ class Simulation(object):
 
         self.output_file = output_file
         self._observables = _Observables(self)
-        self._checkpoint_saver = None
-        self._checkpoint_stride = 0
+        # fixme self._checkpoint_saver = None
+        self._make_checkpoints = False
+        self._checkpoint_format = "checkpoint_{}.h5"
+        self._checkpoint_stride = None
+        self._checkpoint_outdir = None
+        self._checkpoint_max_n_saves = 5
 
         self.integrator = integrator
         self.reaction_handler = reaction_handler
@@ -340,8 +344,11 @@ class Simulation(object):
         import os
         if not os.path.exists(output_directory):
             os.makedirs(output_directory)
-        self._checkpoint_saver = _Saver(str(output_directory), max_n_saves, "checkpoint_{}.h5")
+        self._checkpoint_outdir = output_directory
+        self._checkpoint_max_n_saves = max_n_saves
+        # fixme self._checkpoint_saver = _Saver(str(output_directory), max_n_saves, "checkpoint_{}.h5")
         self._checkpoint_stride = stride
+        self._make_checkpoints = True
 
     @staticmethod
     def list_checkpoints(file_name):
@@ -548,8 +555,9 @@ class Simulation(object):
             loop.neighbor_list_cutoff = max(2. * self._simulation.context.calculate_max_cutoff(), loop.neighbor_list_cutoff)
         if self._skin > 0.:
             loop.neighbor_list_cutoff = loop.neighbor_list_cutoff + self._skin
-        if self._checkpoint_saver is not None:
-            loop.make_checkpoints(self._checkpoint_saver, self._checkpoint_stride)
+        if self._make_checkpoints:
+            loop.make_checkpoints(self._checkpoint_stride, self._checkpoint_outdir,
+                                  self._checkpoint_max_n_saves, self._checkpoint_format)
 
         write_outfile = self.output_file is not None and len(self.output_file) > 0
 

--- a/wrappers/python/src/python/readdy/tests/test_custom_loop.py
+++ b/wrappers/python/src/python/readdy/tests/test_custom_loop.py
@@ -98,7 +98,7 @@ class TestCustomLoop(unittest.TestCase):
             update_nl = simulation._actions.update_neighbor_list()
             reac = simulation._actions.reaction_handler_uncontrolled_approximation(dt)
             obs = simulation._actions.evaluate_observables()
-            check = simulation._actions.make_checkpoint(base_path, max_n_saves)
+            check = simulation._actions.make_checkpoint(base_path, max_n_saves, "checkpoint_{}.h5")
 
             init()
             create_nl()

--- a/wrappers/python/src/python/readdy/tests/test_topology_reaction_count.py
+++ b/wrappers/python/src/python/readdy/tests/test_topology_reaction_count.py
@@ -19,7 +19,7 @@ class TestTopologyReactionCount(unittest.TestCase):
 
     def _test_kernel(self, kernel):
 
-        system = readdy.ReactionDiffusionSystem(box_size=[10, 10, 10])
+        system = readdy.ReactionDiffusionSystem(box_size=[20, 20, 20])
         system.topologies.add_type("T1")
         system.topologies.add_type("T2")
         system.add_species("A")


### PR DESCRIPTION
Changes:
- In `Observable` differentiate naming of `call` and `callback` (these are two different things which were both called `callback`)
- Callback of observables is set by the respective factory. This e.g. enables setting the callback _only_ on the master worker when running MPI Kernel, and discarding it on the workers.
- Move observable registry into `Kernel`
- Wrap the `Saver` and `initializeKernel` calls in the default `SimulationLoop` into `Action`s
- The last two points result in the C++ `Simulation` to be only a thin wrapper around the `Kernel`. I.e. the `Simulation` provides convenient access to the `Kernel` and its `Action`s
- Another result is that one can now use the simulation API also with the MPI kernel (see `kernels/mpi/test/regular/TestObservables.cpp`), which opens the door for writing mpi simulations in python
- Implement most observables for MPI Kernel (yet to be tested)
- Fix a stochastic test, which would fail too often

