### PR TITLE
Test MPI observables

### DIFF
--- a/examples/mpi_scenarios/main.cpp
+++ b/examples/mpi_scenarios/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     // MPI_Init will modify argc, argv such that they behave ''normal'' again, i.e. without the mpirun arguments
     rkm::MPISession mpiSession(argc, argv);
 
-    readdy::log::set_level(spdlog::level::info);
+    readdy::log::set_level(spdlog::level::debug);
 
     // parse argument strings
     auto outdir = perf::getOption(argc, argv, "--outdir=", "/tmp/");
@@ -95,6 +95,7 @@ int main(int argc, char **argv) {
         scenarios.push_back(std::make_unique<perf::MPIDistributeParticles>());
         scenarios.push_back(std::make_unique<perf::MPIDiffusionPairPotential>(
                 perf::WeakScalingGeometry::cube, 13.));
+        scenarios.push_back(std::make_unique<perf::MPILennardJonesSuspension>());
     }
 
 

--- a/examples/scenarios/Scenarios.h
+++ b/examples/scenarios/Scenarios.h
@@ -56,6 +56,69 @@ std::string randomString(std::size_t n = 6) {
     return result.substr(0, n);
 }
 
+class ProgressBar {
+public:
+    ProgressBar(std::size_t total, std::size_t width, bool quiet = false)
+            : _nTicks(total), _width(width), _startTime(std::chrono::steady_clock::now()), _quiet(quiet) {}
+
+    std::size_t operator++() {
+        return increment(1);
+    }
+
+    std::size_t increment(std::size_t deltaTick) {
+        _ticks += deltaTick;
+        return _ticks;
+    }
+
+    std::size_t update(std::size_t newTick) {
+        _ticks = newTick;
+        return _ticks;
+    }
+
+    void display() const {
+        if (_quiet) {
+            return;
+        }
+        std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - _startTime).count();
+
+        auto progress = static_cast<readdy::scalar>(_ticks) / static_cast<readdy::scalar>(_nTicks);
+        auto pos = static_cast<std::size_t>(_width * progress);
+
+        auto percentage = static_cast<std::size_t>(progress * 100.0);
+        auto elapsed = static_cast<readdy::scalar>(duration) / 1000.0;
+        auto prediction = elapsed / progress;
+
+        std::cout << "[";
+        for (std::size_t i = 0; i < _width; ++i) {
+            if (i < pos) {
+                std::cout << _complete;
+            } else if (i == pos) {
+                std::cout << _current;
+            } else {
+                std::cout << _incomplete;
+            }
+        }
+        std::cout << "] " << percentage << "% " << elapsed << "s /" << prediction <<"s\r";
+        std::cout.flush();
+    }
+
+    void done() const {
+        display();
+        std::cout << std::endl;
+    }
+
+private:
+    bool _quiet{false};
+    std::size_t _ticks{0};
+    std::size_t _nTicks;
+    std::size_t _width;
+    char _complete = '=';
+    char _incomplete = ' ';
+    char _current = '>';
+    std::chrono::steady_clock::time_point _startTime;
+};
+
 class Scenario {
     std::string _description{};
     std::string _name{};

--- a/include/readdy/model/observables/ObservableFactory.h
+++ b/include/readdy/model/observables/ObservableFactory.h
@@ -34,9 +34,9 @@
 
 
 /**
- * This header file contains the definition of the ObservableFactory. Its purpose is to create observable of different
- * types in the form of unique_ptrs. The actual implementation of an observable can be changed by specializing the
- * dispatcher for its type and invoking a virtual (and then: overridden) method within the factory.
+ * This header file contains the definition of the ObservableFactory. Its purpose is to create observables of different
+ * types in the form of unique_ptrs. The actual implementation of an observable is determined by the derived
+ * observable factories, which override the factory methods.
  *
  * @file ObservableFactory.h
  * @brief This header file contains the definition of the ObservableFactory.
@@ -95,7 +95,7 @@ public:
     }
     
     [[nodiscard]] std::unique_ptr<NParticles>
-    nParticles(Stride stride, ObsCallback<NParticles> callback) const {
+    nParticles(Stride stride, const ObsCallback<NParticles> &callback) const {
         return std::move(nParticles(stride, {}, callback));
     }
 

--- a/kernels/mpi/src/MPISession.cpp
+++ b/kernels/mpi/src/MPISession.cpp
@@ -40,7 +40,7 @@ void MPISession::waitForDebugger() {
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
         static int rankToDebug = 0;
-        if (rank == rankToDebug or rank == 1) {
+        if (rank == rankToDebug) {
             volatile int i = 0;
             readdy::log::warn("pid {} w/ rank {} on processor {} waiting for debugger",
                               static_cast<unsigned long>(getpid()), rank, processorName);

--- a/kernels/mpi/src/actions/MPIEulerBDIntegrator.cpp
+++ b/kernels/mpi/src/actions/MPIEulerBDIntegrator.cpp
@@ -63,8 +63,6 @@ void MPIEulerBDIntegrator::perform() {
                 bcs::fixPosition(entry.pos, box, pbc);
             }
         }
-        // do the plimpton
-        stateModel.synchronizeWithNeighbors();
     } else {
         readdy::log::trace("MPIEulerBDIntegrator::perform is noop for non workers");
     }

--- a/kernels/mpi/test/regular/IntegrationTests.cpp
+++ b/kernels/mpi/test/regular/IntegrationTests.cpp
@@ -33,8 +33,6 @@
  ********************************************************************/
 
 /**
- *
- *
  * @file TestIntegration.cpp
  * @brief « brief description »
  * @author chrisfroe
@@ -42,11 +40,214 @@
  */
 
 #include <catch2/catch.hpp>
-
 #include <readdy/model/Kernel.h>
-#include <readdy/plugin/KernelProvider.h>
 #include <readdy/kernel/mpi/MPIKernel.h>
+#include <readdy/kernel/singlecpu/SCPUKernel.h>
+#include <readdy/model/RandomProvider.h>
 
-TEST_CASE("Integration test", "[!hide][mpi]") {
-    // there is nothing here
+namespace rnd = readdy::model::rnd;
+namespace rmo = readdy::model::observables;
+namespace rkmu = readdy::kernel::mpi::util;
+
+using ParticlePODSet = std::unordered_set<rkmu::ParticlePOD, rkmu::HashPOD>;
+struct CompareVec3 {
+    bool operator() (const readdy::Vec3 &v1, const readdy::Vec3 &v2) const {return v1.x <  v2.x; }
+};
+
+/// Static in contrast to dynamic (and thus stochastic) results like reaction counts,
+/// i.e. StaticResults only depends on the current particle configuration
+struct StaticResults {
+    rmo::Virial::result_type virial;
+    rmo::Energy::result_type energy;
+    rmo::Positions::result_type positions;
+    rmo::Forces::result_type forces;
+    rmo::Particles::result_type particles;
+    rmo::NParticles::result_type nParticles;
+    // rmo::RadialDistribution::result_type radialDistribution; // not yet implemented for MPI
+    rmo::HistogramAlongAxis::result_type histogramAlongAxis;
+
+    bool operator==(const StaticResults &other) const {
+        // virial, approx the same since order of computation might differ -> rounding errors
+        {
+            const auto &v1 = virial.data();
+            const auto &v2 = other.virial.data();
+            for (std::size_t i = 0; i < v1.size(); ++i) {
+                if (v1[i] != Approx(v2[i])) {
+                    return false;
+                }
+            }
+        }
+
+        // energy, approx the same since order of computation might differ -> rounding errors
+        if (energy != Approx(other.energy)) {
+            return false;
+        }
+
+        // particles, ignore unique ids, ignore order
+        {
+            ParticlePODSet set1;
+            const auto&[types1, ids1, pos1] = particles;
+
+            for (std::size_t i = 0; i < types1.size(); ++i) {
+                set1.emplace(pos1[i], types1[i]);
+            }
+
+            ParticlePODSet set2;
+            const auto&[types2, ids2, pos2] = other.particles;
+            for (std::size_t i = 0; i < types2.size(); ++i) {
+                set2.emplace(pos2[i], types2[i]);
+            }
+
+            if (set1 != set2) {
+                return false;
+            }
+        }
+
+        // positions, ignore order, abuse the ParticlePODSet with a fixed type
+        {
+            ParticlePODSet set1;
+            for (const auto &p : positions) {
+                set1.emplace(p, 0);
+            }
+
+            ParticlePODSet set2;
+            for (const auto &p : other.positions) {
+                set2.emplace(p, 0);
+            }
+
+            if (set1 != set2) {
+                return false;
+            }
+        }
+
+        // forces, sort by x, then must be approximately same
+        {
+            std::vector<readdy::Vec3> f1;
+            for (const auto &f : forces) {
+                f1.push_back(f);
+            }
+            std::sort(f1.begin(), f1.end(), CompareVec3{});
+
+            std::vector<readdy::Vec3> f2;
+            for (const auto &f : other.forces) {
+                f2.push_back(f);
+            }
+            std::sort(f2.begin(), f2.end(), CompareVec3{});
+
+            for (std::size_t i=0; i < f1.size(); ++i) {
+                const auto &v1 = f1[i];
+                const auto &v2 = f2[i];
+                for (std::size_t j = 0; j<3; ++j) {
+                    if (not (v1[j] == Approx(v2[j]))) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // nParticles
+        {
+            if (nParticles.size() != other.nParticles.size()) {
+                return false;
+            }
+            if (not std::equal(nParticles.begin(), nParticles.end(), other.nParticles.begin())) {
+                return false;
+            }
+        }
+
+        // histogramAlongAxis, should be approx same
+        {
+            if (histogramAlongAxis.size() != other.histogramAlongAxis.size()) {
+                return false;
+            }
+            if (not std::equal(histogramAlongAxis.begin(), histogramAlongAxis.end(), other.histogramAlongAxis.begin(),
+                               [](const auto &x1, const auto &x2) -> bool {
+                                   return x1 == Approx(x2);
+                               })) {
+                return false;
+            }
+        }
+
+        // all good
+        return true;
+    }
+};
+
+readdy::model::Context getContext() {
+    readdy::model::Context ctx;
+    ctx.boxSize() = {10., 10., 10.};
+    ctx.kernelConfiguration().mpi.dx = 4.9;
+    ctx.kernelConfiguration().mpi.dy = 4.9;
+    ctx.kernelConfiguration().mpi.dz = 4.9;
+    ctx.particleTypes().add("A", 0.5);
+    ctx.particleTypes().add("B", 1.0);
+    ctx.reactions().add("fusion: B +(1) B -> A", 100.);
+    ctx.potentials().addHarmonicRepulsion("B", "B", 1., 2.);
+    return ctx;
+}
+
+StaticResults observeState(const std::vector<readdy::model::Particle> &initParticles, readdy::model::Kernel *kernel) {
+    auto virial = kernel->observe().virial(1);
+    auto energy = kernel->observe().energy(1);
+    auto positions = kernel->observe().positions(1);
+    auto forces = kernel->observe().forces(1);
+    auto particles = kernel->observe().particles(1);
+    auto nParticles = kernel->observe().nParticles(1);
+    auto histogramAlongAxis = kernel->observe().histogramAlongAxis(1, {-1, 0.5, 0.5, 1}, {"B"}, 0);
+
+    kernel->actions().addParticles(initParticles)->perform();
+    kernel->actions().initializeKernel()->perform();
+    kernel->actions().createNeighborList(kernel->context().calculateMaxCutoff())->perform();
+    kernel->actions().updateNeighborList()->perform();
+    kernel->actions().calculateForces()->perform();
+
+    virial->call(0);
+    energy->call(0);
+    positions->call(0);
+    forces->call(0);
+    particles->call(0);
+    nParticles->call(0);
+    histogramAlongAxis->call(0);
+
+    return {
+            .virial = virial->getResult(),
+            .energy = energy->getResult(),
+            .positions = positions->getResult(),
+            .forces = forces->getResult(),
+            .particles = particles->getResult(),
+            .nParticles = nParticles->getResult(),
+            .histogramAlongAxis = histogramAlongAxis->getResult(),
+    };
+}
+
+TEST_CASE("Integration test state observables compared to SCPU", "[mpi]") {
+    auto ctx = getContext();
+    double volumeOccupation{0.7};
+    auto numberParticles = static_cast<std::size_t>(
+            volumeOccupation * ctx.boxVolume() / (
+                    4. / 3. * readdy::util::numeric::pi<double>() * std::pow(ctx.calculateMaxCutoff() / 2., 3)
+            )
+    );
+
+    const auto &box = ctx.boxSize();
+    auto idB = ctx.particleTypes().idOf("B");
+    std::vector<readdy::model::Particle> initParticles;
+    for (std::size_t i = 0; i < numberParticles; ++i) {
+        readdy::Vec3 p{rnd::uniform_real() * box[0] - 0.5 * box[0],
+                       rnd::uniform_real() * box[1] - 0.5 * box[1],
+                       rnd::uniform_real() * box[2] - 0.5 * box[2]};
+        initParticles.emplace_back(p, idB);
+    }
+
+    readdy::kernel::mpi::MPIKernel mpiKernel(ctx);
+
+    if (not mpiKernel.domain().isIdleRank()) {
+        StaticResults mpiResults = observeState(initParticles, &mpiKernel);
+        if (mpiKernel.domain().isMasterRank()) {
+            readdy::kernel::scpu::SCPUKernel scpuKernel;
+            scpuKernel.context() = ctx;
+            StaticResults scpuResults = observeState(initParticles, &scpuKernel);
+            REQUIRE(mpiResults == scpuResults);
+        }
+    }
 }


### PR DESCRIPTION
## Changes
- Fixes in observables
- Test for observables that checks the results against the SCPU Kernel
- Scenario to run the LJ suspension

## Equilibrium Lennard-Jones system
The same LJ suspension (density 0.3, temperature 3, cutoff 4) as in https://doi.org/10.1371/journal.pcbi.1006830 was run with the MPI kernel. Results of pressure and potential energy per particle
```
energy -1.643 +- 0.007
pressure 1.010 +- 0.01
```
roughly agree with the literature values and what was measured in other ReaDDy kernels and HALMD (https://readdy.github.io/validation/lennard_jones_fluid). Errors over 4 samples, equilibration could have been longer.