### PR TITLE
Fix frozen dict implementation

### DIFF
--- a/wrappers/python/src/python/readdy/util/frozen_dict.py
+++ b/wrappers/python/src/python/readdy/util/frozen_dict.py
@@ -2,10 +2,10 @@
 
 # taken from https://stackoverflow.com/a/2704866/2871028
 
-import collections
+from collections.abc import Mapping
 
 
-class FrozenDict(collections.Mapping):
+class FrozenDict(Mapping):
     """Don't forget the docstrings!!"""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
`collections.Mapping` exclusively lives in `collections.abc.Mapping` from Python 3.10 on 